### PR TITLE
Add --claude flag for Claude API pass-through mode

### DIFF
--- a/src/cc_forge/cli.py
+++ b/src/cc_forge/cli.py
@@ -31,6 +31,9 @@ def run(repo: str, agent: str, claude_passthrough: bool) -> None:
     from cc_forge.config import load_config
     from cc_forge.session import start_session
 
+    if claude_passthrough and agent != "claude":
+        raise click.UsageError("--claude can only be used with --agent claude")
+
     cfg = load_config()
     start_session(cfg, repo_path=repo, agent=agent, claude_passthrough=claude_passthrough)
 

--- a/src/cc_forge/cli.py
+++ b/src/cc_forge/cli.py
@@ -24,13 +24,15 @@ def main(ctx: click.Context) -> None:
 @click.option("--repo", default=".", help="Path to git repository (default: current directory).")
 @click.option("--agent", default="claude", type=click.Choice(["claude", "aider"]),
               help="Agent to use inside the container.")
-def run(repo: str, agent: str) -> None:
+@click.option("--claude", "claude_passthrough", is_flag=True,
+              help="Use your Claude API account instead of local Ollama.")
+def run(repo: str, agent: str, claude_passthrough: bool) -> None:
     """Start an interactive agent session."""
     from cc_forge.config import load_config
     from cc_forge.session import start_session
 
     cfg = load_config()
-    start_session(cfg, repo_path=repo, agent=agent)
+    start_session(cfg, repo_path=repo, agent=agent, claude_passthrough=claude_passthrough)
 
 
 @main.command()

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
@@ -89,12 +90,41 @@ def ensure_agent_image_built(config: ForgeConfig) -> str:
     return image_tag
 
 
+def _ollama_environment(config: ForgeConfig) -> dict[str, str]:
+    """Environment variables for local Ollama backend."""
+    ollama_url = _rewrite_url(config.ollama_cpu_url, "host.docker.internal")
+    return {
+        "OLLAMA_HOST": ollama_url,
+        "ANTHROPIC_AUTH_TOKEN": "ollama",
+        "ANTHROPIC_BASE_URL": ollama_url,
+        "DISABLE_PROMPT_CACHING": "true",
+        "API_TIMEOUT_MS": "3600000",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        "MAX_THINKING_TOKENS": "0",
+    }
+
+
+def _claude_environment() -> dict[str, str]:
+    """Environment variables for Claude API pass-through."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY not set. Required for --claude pass-through mode.\n"
+            "Set it in your environment or ~/.config/forge/config.env"
+        )
+    return {
+        "ANTHROPIC_API_KEY": api_key,
+    }
+
+
 def run_agent_container(
     config: ForgeConfig,
     repo_url: str,
     branch: str,
     repo_name: str,
     agent: str = "claude",
+    claude_passthrough: bool = False,
 ) -> str:
     """Launch an agent container on forge-network. Returns container ID."""
     client = _docker_client()
@@ -103,33 +133,28 @@ def run_agent_container(
     container_name = f"{CONTAINER_PREFIX}{repo_name}-{int(time.time())}"
 
     # Rewrite URLs for container network: localhost → Docker service names.
-    # Ollama bypasses the socat proxies and connects directly to the host
-    # via host.docker.internal — socat drops idle connections during long
-    # CPU prefills (~5 min). Requires OLLAMA_HOST=0.0.0.0 on the host.
     clone_url = _rewrite_url(repo_url, "forge-forgejo")
-    ollama_url = _rewrite_url(config.ollama_cpu_url, "host.docker.internal")
     forgejo_url = _rewrite_url(config.forgejo_url, "forge-forgejo")
+
+    environment = {
+        "FORGEJO_URL": forgejo_url,
+        "FORGEJO_TOKEN": config.forgejo_token,
+        "REPO_URL": clone_url,
+        "REPO_BRANCH": branch,
+        "FORGE_AGENT": agent,
+    }
+
+    if claude_passthrough:
+        environment.update(_claude_environment())
+    else:
+        environment.update(_ollama_environment(config))
 
     container = client.containers.run(
         image_tag,
         detach=True,
         name=container_name,
         network="forge-network",
-        environment={
-            "FORGEJO_URL": forgejo_url,
-            "FORGEJO_TOKEN": config.forgejo_token,
-            "REPO_URL": clone_url,
-            "REPO_BRANCH": branch,
-            "FORGE_AGENT": agent,
-            "OLLAMA_HOST": ollama_url,
-            "ANTHROPIC_AUTH_TOKEN": "ollama",
-            "ANTHROPIC_BASE_URL": ollama_url,
-            "DISABLE_PROMPT_CACHING": "true",
-            "API_TIMEOUT_MS": "3600000",
-            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
-            "MAX_THINKING_TOKENS": "0",
-        },
+        environment=environment,
         labels={"forge.role": "agent", "forge.repo": repo_name},
         extra_hosts={"host.docker.internal": "host-gateway"},
     )
@@ -164,12 +189,19 @@ def wait_for_ready(container_id: str, timeout: int = 60) -> None:
     raise RuntimeError(f"Timed out waiting for repo clone.\nContainer logs:\n{logs}")
 
 
-def exec_agent(container_id: str, agent: str, config: ForgeConfig) -> int:
+def exec_agent(
+    container_id: str,
+    agent: str,
+    config: ForgeConfig,
+    claude_passthrough: bool = False,
+) -> int:
     """Exec the agent interactively inside a running container. Returns exit code."""
     wait_for_ready(container_id)
 
     if agent == "claude":
-        cmd = ["claude", "--dangerously-skip-permissions", "--model", config.claude_model]
+        cmd = ["claude", "--dangerously-skip-permissions"]
+        if not claude_passthrough:
+            cmd += ["--model", config.claude_model]
     elif agent == "aider":
         cmd = ["aider", "--model", "ollama/llama3.1"]
     else:

--- a/src/cc_forge/session.py
+++ b/src/cc_forge/session.py
@@ -93,7 +93,7 @@ def start_session(
                     click.echo("Warning: could not restore forgejo remote URL.", err=True)
 
     # 7. Launch agent container
-    backend = "Claude API" if claude_passthrough else "local Ollama"
+    backend = "Claude API" if claude_passthrough and agent == "claude" else "local Ollama"
     click.echo(f"Starting {agent} agent container ({backend})...")
     container_id = run_agent_container(
         config,

--- a/src/cc_forge/session.py
+++ b/src/cc_forge/session.py
@@ -29,7 +29,12 @@ from cc_forge.git import (
 )
 
 
-def start_session(config: ForgeConfig, repo_path: str = ".", agent: str = "claude") -> None:
+def start_session(
+    config: ForgeConfig,
+    repo_path: str = ".",
+    agent: str = "claude",
+    claude_passthrough: bool = False,
+) -> None:
     """Run the full forge session flow."""
     path = Path(repo_path).resolve()
 
@@ -88,20 +93,22 @@ def start_session(config: ForgeConfig, repo_path: str = ".", agent: str = "claud
                     click.echo("Warning: could not restore forgejo remote URL.", err=True)
 
     # 7. Launch agent container
-    click.echo(f"Starting {agent} agent container...")
+    backend = "Claude API" if claude_passthrough else "local Ollama"
+    click.echo(f"Starting {agent} agent container ({backend})...")
     container_id = run_agent_container(
         config,
         repo_url=clone_url,
         branch=branch,
         repo_name=repo_name,
         agent=agent,
+        claude_passthrough=claude_passthrough,
     )
     click.echo(f"Container started. Launching {agent}...")
     click.echo("---")
 
     # 8. Exec agent interactively and wait
     try:
-        exec_agent(container_id, agent, config)
+        exec_agent(container_id, agent, config, claude_passthrough=claude_passthrough)
     finally:
         click.echo("\n--- Session ended. Cleaning up container...")
         cleanup_container(container_id)


### PR DESCRIPTION
## Summary

- Adds `forge run --claude` to use your Claude API account instead of local Ollama
- Default behavior (`forge run`) is unchanged — still uses local Ollama
- Containers already have internet access (standard Docker bridge), so no network changes needed
- Requires `ANTHROPIC_API_KEY` in host environment; fails fast with a clear error if missing

## Changes

- **cli.py**: New `--claude` flag on `run` command
- **docker.py**: Split env setup into `_ollama_environment()` and `_claude_environment()`. In pass-through mode, no Ollama overrides are set, just the API key. `exec_agent` skips `--model` flag so Claude Code uses its default.
- **session.py**: Threads `claude_passthrough` flag through to docker functions
- **tests**: 3 new tests for environment helpers (Ollama vars, API key pass-through, missing key error)

## Usage

```bash
# Local Ollama (default, unchanged)
forge run

# Claude API pass-through
export ANTHROPIC_API_KEY=sk-ant-...
forge run --claude
```

Closes #34

## Test plan

- [ ] `pytest` passes (29/29)
- [ ] `forge run` still works with local Ollama (no regression)
- [ ] `forge run --claude` with `ANTHROPIC_API_KEY` set launches Claude Code against real API
- [ ] `forge run --claude` without `ANTHROPIC_API_KEY` fails with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)