### PR TITLE
Persist Claude OAuth + state across --claude pass-through sessions

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -37,8 +37,9 @@ RUN sed -i 's/?beta=true//g' /usr/local/lib/node_modules/@anthropic-ai/claude-co
         exit 1; \
     fi
 
-# Create non-root user
-RUN useradd -m -s /bin/bash agent && \
+# Create non-root user (remove ubuntu default to claim UID 1000)
+RUN userdel -r ubuntu 2>/dev/null; \
+    useradd -m -s /bin/bash -u 1000 agent && \
     mkdir -p /workspace && \
     chown -R agent:agent /workspace
 

--- a/src/cc_forge/config.py
+++ b/src/cc_forge/config.py
@@ -32,6 +32,7 @@ _DEFAULTS = {
     "FORGE_OLLAMA_GPU_URL": "http://localhost:11435",
     "FORGE_AGENT_IMAGE": "cc-forge-agent:latest",
     "FORGE_CLAUDE_MODEL": "qwen3-coder-32k",
+    "FORGE_CLAUDE_API_KEY": "",
     "FORGE_COMPOSE_FILE": "",
 }
 
@@ -84,6 +85,7 @@ class ForgeConfig:
     ollama_gpu_url: str = field(default_factory=lambda: _resolve("FORGE_OLLAMA_GPU_URL"))
     agent_image: str = field(default_factory=lambda: _resolve("FORGE_AGENT_IMAGE"))
     claude_model: str = field(default_factory=lambda: _resolve("FORGE_CLAUDE_MODEL"))
+    claude_api_key: str = field(default_factory=lambda: _resolve("FORGE_CLAUDE_API_KEY"))
     compose_file: str = field(default_factory=lambda: _resolve("FORGE_COMPOSE_FILE"))
 
 

--- a/src/cc_forge/config.py
+++ b/src/cc_forge/config.py
@@ -85,7 +85,10 @@ class ForgeConfig:
     ollama_gpu_url: str = field(default_factory=lambda: _resolve("FORGE_OLLAMA_GPU_URL"))
     agent_image: str = field(default_factory=lambda: _resolve("FORGE_AGENT_IMAGE"))
     claude_model: str = field(default_factory=lambda: _resolve("FORGE_CLAUDE_MODEL"))
-    claude_api_key: str = field(default_factory=lambda: _resolve("FORGE_CLAUDE_API_KEY"))
+    claude_api_key: str = field(
+        default_factory=lambda: _resolve("FORGE_CLAUDE_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY", "")
+    )
     compose_file: str = field(default_factory=lambda: _resolve("FORGE_COMPOSE_FILE"))
 
 

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -185,6 +185,8 @@ def _claude_environment() -> dict[str, str]:
         # Override Dockerfile defaults that would route to Ollama
         "ANTHROPIC_BASE_URL": "",
         "ANTHROPIC_AUTH_TOKEN": "",
+        # Container agent can't write to npm global; skip auto-update
+        "CLAUDE_CODE_SKIP_UPDATE": "1",
     }
 
 
@@ -336,6 +338,8 @@ def cleanup_container(container_id: str) -> None:
         container.remove()
     except NotFound:
         pass  # Already removed — nothing to clean up
+    except docker.errors.APIError:
+        pass  # Removal already in progress or other transient error
 
 
 def stop_container(container_id: str) -> None:

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -140,6 +140,14 @@ def _copy_claude_config(container, config: ForgeConfig) -> None:
 
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w") as tar:
+        # .claude/ directory (must be explicit so agent owns it and can write)
+        dir_info = tarfile.TarInfo(name=".claude/")
+        dir_info.type = tarfile.DIRTYPE
+        dir_info.uid = AGENT_UID
+        dir_info.gid = AGENT_UID
+        dir_info.mode = 0o755
+        tar.addfile(dir_info)
+
         # OAuth credentials
         _add_tar_file(tar, ".claude/.credentials.json",
                       cred_path.read_bytes(), mode=0o600)

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -196,6 +196,8 @@ def run_agent_container(
         environment=environment,
         labels={"forge.role": "agent", "forge.repo": repo_name},
         extra_hosts={"host.docker.internal": "host-gateway"},
+        stdin_open=True,
+        tty=True,
     )
 
     if claude_passthrough:

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -110,12 +110,14 @@ def _forge_claude_state_dir() -> Path:
 
 def _claude_credentials_path() -> Path:
     """Return the path to Claude OAuth credentials (saved state preferred, then host)."""
-    saved = _forge_claude_state_dir() / ".credentials.json"
-    if saved.is_file():
-        return saved
-    host = Path.home() / ".claude" / ".credentials.json"
-    if host.is_file():
-        return host
+    for candidate in (
+        _forge_claude_state_dir() / ".credentials.json",
+        Path.home() / ".claude" / ".credentials.json",
+    ):
+        if candidate.is_symlink():
+            raise RuntimeError(f"Refusing to use symlinked credentials: {candidate}")
+        if candidate.is_file():
+            return candidate
     raise RuntimeError(
         "Claude credentials not found.\n"
         "Either set FORGE_CLAUDE_API_KEY or run 'claude' locally to authenticate."
@@ -343,6 +345,7 @@ def save_claude_credentials(container_id: str) -> None:
     import io
     import shutil
     import tarfile
+    import tempfile
 
     client = _docker_client()
     state_dir = _forge_claude_state_dir()
@@ -364,26 +367,29 @@ def save_claude_credentials(container_id: str) -> None:
         buf.write(chunk)
     buf.seek(0)
 
-    tmp_dir = state_dir.parent / "claude-state-tmp"
-    if tmp_dir.exists():
-        shutil.rmtree(tmp_dir)
-    tmp_dir.mkdir(parents=True)
+    state_dir.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=state_dir.parent, prefix="claude-state-tmp-"
+    ) as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            for member in tar.getmembers():
+                parts = Path(member.name).parts
+                if any(p in _SKIP_PATTERNS for p in parts):
+                    continue
+                if ".git" in parts:
+                    continue
+                tar.extract(member, tmp_dir, filter="data")
 
-    with tarfile.open(fileobj=buf, mode="r") as tar:
-        for member in tar.getmembers():
-            parts = Path(member.name).parts
-            if any(p in _SKIP_PATTERNS for p in parts):
-                continue
-            if ".git" in parts:
-                continue
-            tar.extract(member, tmp_dir, filter="data")
+        extracted = tmp_dir / ".claude" if (tmp_dir / ".claude").exists() else tmp_dir
+        if state_dir.exists():
+            shutil.rmtree(state_dir)
+        shutil.move(str(extracted), str(state_dir))
 
-    extracted = tmp_dir / ".claude" if (tmp_dir / ".claude").exists() else tmp_dir
-    if state_dir.exists():
-        shutil.rmtree(state_dir)
-    shutil.move(str(extracted), str(state_dir))
-    if tmp_dir.exists():
-        shutil.rmtree(tmp_dir)
+    state_dir.chmod(0o700)
+    cred_file = state_dir / ".credentials.json"
+    if cred_file.is_file():
+        cred_file.chmod(0o600)
 
     # Also save ~/.claude.json (onboarding/account state)
     try:
@@ -401,7 +407,11 @@ def save_claude_credentials(container_id: str) -> None:
                 f = tar.extractfile(member)
                 if f:
                     state_dir.mkdir(parents=True, exist_ok=True)
-                    (state_dir / ".claude.json").write_bytes(f.read())
+                    target = state_dir / ".claude.json"
+                    tmp = state_dir / ".claude.json.tmp"
+                    tmp.write_bytes(f.read())
+                    tmp.chmod(0o600)
+                    tmp.replace(target)
                 break
 
 

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -104,12 +104,13 @@ def _ollama_environment(config: ForgeConfig) -> dict[str, str]:
     }
 
 
-FORGE_CLAUDE_STATE = Path.home() / ".config" / "forge" / "claude-state"
+def _forge_claude_state_dir() -> Path:
+    return Path.home() / ".config" / "forge" / "claude-state"
 
 
 def _claude_credentials_path() -> Path:
-    """Return the path to Claude OAuth credentials (saved state or host)."""
-    saved = FORGE_CLAUDE_STATE / ".credentials.json"
+    """Return the path to Claude OAuth credentials (saved state preferred, then host)."""
+    saved = _forge_claude_state_dir() / ".credentials.json"
     if saved.is_file():
         return saved
     host = Path.home() / ".claude" / ".credentials.json"
@@ -166,22 +167,21 @@ def _copy_claude_config(container, config: ForgeConfig) -> None:
 
         if need_credentials:
             cred_path = _claude_credentials_path()
+            state_dir = _forge_claude_state_dir()
 
-            # Walk saved state directory and inject everything
-            if FORGE_CLAUDE_STATE.is_dir():
-                for path in FORGE_CLAUDE_STATE.rglob("*"):
-                    rel = path.relative_to(FORGE_CLAUDE_STATE)
+            # Inject saved state as baseline (skip credentials — we'll add fresh ones)
+            if state_dir.is_dir():
+                for path in state_dir.rglob("*"):
+                    rel = path.relative_to(state_dir)
+                    if rel.name == ".credentials.json":
+                        continue
                     arc_name = f".claude/{rel}"
                     if path.is_dir():
                         _add_tar_dir(tar, arc_name + "/")
                     else:
-                        mode = 0o600 if path.name == ".credentials.json" else 0o644
-                        _add_tar_file(tar, arc_name, path.read_bytes(), mode=mode)
-            else:
-                _add_tar_file(tar, ".claude/.credentials.json",
-                              cred_path.read_bytes(), mode=0o600)
+                        _add_tar_file(tar, arc_name, path.read_bytes())
 
-            # Always inject fresh credentials (may be newer than saved state)
+            # Inject credentials once (saved-preferred, host fallback)
             _add_tar_file(tar, ".claude/.credentials.json",
                           cred_path.read_bytes(), mode=0o600)
 
@@ -194,7 +194,7 @@ def _copy_claude_config(container, config: ForgeConfig) -> None:
 
         # $HOME/.claude.json — onboarding bypass + saved state
         # hasCompletedOnboarding lives here (NOT in settings.json)
-        saved_claude_json = FORGE_CLAUDE_STATE / ".claude.json"
+        saved_claude_json = _forge_claude_state_dir() / ".claude.json"
         if saved_claude_json.is_file():
             _add_tar_file(tar, ".claude.json",
                           saved_claude_json.read_bytes(), mode=0o600)
@@ -262,10 +262,17 @@ def run_agent_container(
         tty=True,
     )
 
-    if claude_passthrough:
-        _copy_claude_config(container, config)
+    try:
+        if claude_passthrough:
+            _copy_claude_config(container, config)
+        container.start()
+    except Exception:
+        try:
+            container.remove(force=True)
+        except docker.errors.APIError:
+            pass
+        raise
 
-    container.start()
     return container.id
 
 
@@ -338,57 +345,64 @@ def save_claude_credentials(container_id: str) -> None:
     import tarfile
 
     client = _docker_client()
+    state_dir = _forge_claude_state_dir()
     _SKIP_PATTERNS = {"debug", "session-env", "file-history", "shell-snapshots"}
 
     try:
         container = client.containers.get(container_id)
+    except NotFound:
+        return
+
+    try:
         bits, _ = container.get_archive("/home/agent/.claude/.")
-        buf = io.BytesIO()
-        for chunk in bits:
-            buf.write(chunk)
-        buf.seek(0)
+    except docker.errors.APIError:
+        click.echo("Warning: could not read Claude state from container.", err=True)
+        return
 
-        # Extract to temp, then swap into place
-        tmp_dir = FORGE_CLAUDE_STATE.parent / "claude-state-tmp"
-        if tmp_dir.exists():
-            shutil.rmtree(tmp_dir)
-        tmp_dir.mkdir(parents=True)
+    buf = io.BytesIO()
+    for chunk in bits:
+        buf.write(chunk)
+    buf.seek(0)
 
-        with tarfile.open(fileobj=buf, mode="r") as tar:
-            for member in tar.getmembers():
-                parts = Path(member.name).parts
-                # Skip debug, git repos, and large transient data
-                if any(p in _SKIP_PATTERNS for p in parts):
-                    continue
-                if ".git" in parts:
-                    continue
-                tar.extract(member, tmp_dir, filter="data")
+    tmp_dir = state_dir.parent / "claude-state-tmp"
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True)
 
-        # Move extracted files into place (strip the top-level directory)
-        extracted = tmp_dir / ".claude" if (tmp_dir / ".claude").exists() else tmp_dir
-        if FORGE_CLAUDE_STATE.exists():
-            shutil.rmtree(FORGE_CLAUDE_STATE)
-        shutil.move(str(extracted), str(FORGE_CLAUDE_STATE))
-        if tmp_dir.exists():
-            shutil.rmtree(tmp_dir)
+    with tarfile.open(fileobj=buf, mode="r") as tar:
+        for member in tar.getmembers():
+            parts = Path(member.name).parts
+            if any(p in _SKIP_PATTERNS for p in parts):
+                continue
+            if ".git" in parts:
+                continue
+            tar.extract(member, tmp_dir, filter="data")
 
-        # Also save $HOME/.claude.json (main state file with userID/account)
-        try:
-            bits2, _ = container.get_archive("/home/agent/.claude.json")
-            buf2 = io.BytesIO()
-            for chunk in bits2:
-                buf2.write(chunk)
-            buf2.seek(0)
-            with tarfile.open(fileobj=buf2, mode="r") as tar:
-                member = tar.getmembers()[0]
+    extracted = tmp_dir / ".claude" if (tmp_dir / ".claude").exists() else tmp_dir
+    if state_dir.exists():
+        shutil.rmtree(state_dir)
+    shutil.move(str(extracted), str(state_dir))
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+
+    # Also save ~/.claude.json (onboarding/account state)
+    try:
+        bits2, _ = container.get_archive("/home/agent/.claude.json")
+    except docker.errors.APIError:
+        return
+
+    buf2 = io.BytesIO()
+    for chunk in bits2:
+        buf2.write(chunk)
+    buf2.seek(0)
+    with tarfile.open(fileobj=buf2, mode="r") as tar:
+        for member in tar.getmembers():
+            if member.isreg():
                 f = tar.extractfile(member)
                 if f:
-                    (FORGE_CLAUDE_STATE / ".claude.json").write_bytes(f.read())
-        except Exception:
-            pass  # May not exist on first run
-
-    except Exception:
-        pass  # Best-effort; don't fail the session over this
+                    state_dir.mkdir(parents=True, exist_ok=True)
+                    (state_dir / ".claude.json").write_bytes(f.read())
+                break
 
 
 def cleanup_container(container_id: str) -> None:

--- a/src/cc_forge/session.py
+++ b/src/cc_forge/session.py
@@ -12,6 +12,7 @@ from cc_forge.docker import (
     ensure_infrastructure_running,
     exec_agent,
     run_agent_container,
+    save_claude_credentials,
 )
 
 from cc_forge.forgejo import ForgejoClient
@@ -110,6 +111,8 @@ def start_session(
     try:
         exec_agent(container_id, agent, config, claude_passthrough=claude_passthrough)
     finally:
+        if claude_passthrough:
+            save_claude_credentials(container_id)
         click.echo("\n--- Session ended. Cleaning up container...")
         cleanup_container(container_id)
 

--- a/src/cc_forge/session.py
+++ b/src/cc_forge/session.py
@@ -111,7 +111,7 @@ def start_session(
     try:
         exec_agent(container_id, agent, config, claude_passthrough=claude_passthrough)
     finally:
-        if claude_passthrough:
+        if claude_passthrough and not config.claude_api_key:
             save_claude_credentials(container_id)
         click.echo("\n--- Session ended. Cleaning up container...")
         cleanup_container(container_id)

--- a/src/cc_forge/session.py
+++ b/src/cc_forge/session.py
@@ -112,7 +112,10 @@ def start_session(
         exec_agent(container_id, agent, config, claude_passthrough=claude_passthrough)
     finally:
         if claude_passthrough and not config.claude_api_key:
-            save_claude_credentials(container_id)
+            try:
+                save_claude_credentials(container_id)
+            except Exception as e:
+                click.echo(f"Warning: failed to save Claude state: {e}", err=True)
         click.echo("\n--- Session ended. Cleaning up container...")
         cleanup_container(container_id)
 

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -8,6 +8,7 @@ from cc_forge.docker import (
     _rewrite_url,
     _ollama_environment,
     _claude_environment,
+    _claude_credentials_path,
     _build_agent_cmd,
 )
 
@@ -71,22 +72,28 @@ class TestOllamaEnvironment:
 
 
 class TestClaudeEnvironment:
-    def test_passes_api_key(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key-123")
-        env = _claude_environment()
-        assert env["ANTHROPIC_API_KEY"] == "sk-test-key-123"
-        assert "DISABLE_PROMPT_CACHING" not in env
-
-    def test_overrides_dockerfile_defaults(self, monkeypatch):
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key-123")
+    def test_overrides_dockerfile_defaults(self):
         env = _claude_environment()
         assert env["ANTHROPIC_BASE_URL"] == ""
         assert env["ANTHROPIC_AUTH_TOKEN"] == ""
 
-    def test_raises_without_api_key(self, monkeypatch):
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY not set"):
-            _claude_environment()
+    def test_no_api_key_in_env(self):
+        env = _claude_environment()
+        assert "ANTHROPIC_API_KEY" not in env
+
+
+class TestClaudeCredentialsPath:
+    def test_returns_path_when_exists(self, tmp_path, monkeypatch):
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir()
+        cred_file.write_text('{"claudeAiOauth": {}}')
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        assert _claude_credentials_path() == cred_file
+
+    def test_raises_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        with pytest.raises(RuntimeError, match="credentials not found"):
+            _claude_credentials_path()
 
 
 class TestBuildAgentCmd:

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -1,15 +1,22 @@
 """Tests for docker module helpers."""
 from __future__ import annotations
 
+import io
+import tarfile
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from cc_forge.config import ForgeConfig
 from cc_forge.docker import (
+    AGENT_UID,
     _rewrite_url,
     _ollama_environment,
     _claude_environment,
     _claude_credentials_path,
+    _copy_claude_config,
     _build_agent_cmd,
+    save_claude_credentials,
 )
 
 
@@ -25,6 +32,25 @@ def _make_config(**kwargs) -> ForgeConfig:
     )
     defaults.update(kwargs)
     return ForgeConfig(**defaults)
+
+
+def _make_tar(files: dict[str, bytes]) -> io.BytesIO:
+    """Create an in-memory tar archive from {path: content} dict."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    return buf
+
+
+def _inspect_tar(buf: io.BytesIO) -> dict[str, tarfile.TarInfo]:
+    """Return {name: TarInfo} for all members in a tar buffer."""
+    buf.seek(0)
+    with tarfile.open(fileobj=buf, mode="r") as tar:
+        return {m.name: m for m in tar.getmembers()}
 
 
 class TestRewriteUrl:
@@ -104,7 +130,9 @@ class TestClaudeCredentialsPath:
             _claude_credentials_path()
 
     def test_prefers_saved_state(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("cc_forge.docker.FORGE_CLAUDE_STATE", tmp_path)
+        monkeypatch.setattr(
+            "cc_forge.docker._forge_claude_state_dir", lambda: tmp_path
+        )
         saved = tmp_path / ".credentials.json"
         saved.write_text('{"saved": true}')
         assert _claude_credentials_path() == saved
@@ -131,3 +159,263 @@ class TestBuildAgentCmd:
         config = _make_config()
         cmd = _build_agent_cmd("bash", config)
         assert cmd == ["/bin/bash"]
+
+
+class TestCopyClaudeConfig:
+    """Tests for _copy_claude_config tar injection."""
+
+    def _capture_container(self):
+        """Return a mock container that captures put_archive calls."""
+        container = MagicMock()
+        container.captured_bufs = []
+
+        def capture_put_archive(path, buf):
+            container.captured_bufs.append((path, buf))
+
+        container.put_archive = capture_put_archive
+        return container
+
+    def _get_tar_members(self, container) -> dict[str, tarfile.TarInfo]:
+        """Extract tar members from the captured put_archive call."""
+        assert container.captured_bufs, "put_archive was never called"
+        _, buf = container.captured_bufs[0]
+        return _inspect_tar(buf)
+
+    def _get_tar_content(self, container, name: str) -> bytes:
+        """Extract file content from the captured tar."""
+        _, buf = container.captured_bufs[0]
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            f = tar.extractfile(name)
+            assert f is not None, f"{name} not extractable"
+            return f.read()
+
+    def test_api_key_mode_skips_credentials(self, tmp_path):
+        config = _make_config(claude_api_key="sk-test", compose_file=str(tmp_path / "docker-compose.yml"))
+        container = self._capture_container()
+
+        _copy_claude_config(container, config)
+
+        members = self._get_tar_members(container)
+        assert ".claude/.credentials.json" not in members
+
+    def test_first_run_injects_host_credentials(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: tmp_path / "nonexistent")
+        host_creds = tmp_path / ".claude" / ".credentials.json"
+        host_creds.parent.mkdir(parents=True)
+        host_creds.write_bytes(b'{"host": true}')
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        config = _make_config(compose_file=str(tmp_path / "docker-compose.yml"))
+        container = self._capture_container()
+
+        _copy_claude_config(container, config)
+
+        content = self._get_tar_content(container, ".claude/.credentials.json")
+        assert content == b'{"host": true}'
+
+    def test_first_run_injects_minimal_claude_json(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: tmp_path / "nonexistent")
+        host_creds = tmp_path / ".claude" / ".credentials.json"
+        host_creds.parent.mkdir(parents=True)
+        host_creds.write_bytes(b'{"host": true}')
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        config = _make_config(compose_file=str(tmp_path / "docker-compose.yml"))
+        container = self._capture_container()
+
+        _copy_claude_config(container, config)
+
+        content = self._get_tar_content(container, ".claude.json")
+        assert b"hasCompletedOnboarding" in content
+
+    def test_saved_state_injected_as_baseline(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / ".credentials.json").write_bytes(b'{"saved": true}')
+        (state_dir / "settings.json").write_bytes(b'{"setting": 1}')
+        subdir = state_dir / "projects"
+        subdir.mkdir()
+        (subdir / "config.json").write_bytes(b'{"project": 1}')
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: state_dir)
+
+        config = _make_config(compose_file=str(tmp_path / "docker-compose.yml"))
+        container = self._capture_container()
+
+        _copy_claude_config(container, config)
+
+        members = self._get_tar_members(container)
+        assert ".claude/settings.json" in members
+        assert ".claude/projects" in members
+        assert ".claude/projects/config.json" in members
+
+    def test_saved_credentials_preferred_over_host(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / ".credentials.json").write_bytes(b'{"saved": true}')
+
+        host_creds = tmp_path / ".claude" / ".credentials.json"
+        host_creds.parent.mkdir(parents=True)
+        host_creds.write_bytes(b'{"host": true}')
+
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: state_dir)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        config = _make_config(compose_file=str(tmp_path / "docker-compose.yml"))
+        container = self._capture_container()
+
+        _copy_claude_config(container, config)
+
+        content = self._get_tar_content(container, ".claude/.credentials.json")
+        assert content == b'{"saved": true}'
+
+    def test_permissions_and_ownership(self, tmp_path, monkeypatch):
+        host_creds = tmp_path / ".claude" / ".credentials.json"
+        host_creds.parent.mkdir(parents=True)
+        host_creds.write_bytes(b'{"creds": true}')
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: tmp_path / "nonexistent")
+
+        config = _make_config(compose_file=str(tmp_path / "docker-compose.yml"))
+        container = self._capture_container()
+
+        _copy_claude_config(container, config)
+
+        members = self._get_tar_members(container)
+        creds = members[".claude/.credentials.json"]
+        assert creds.mode == 0o600
+        assert creds.uid == AGENT_UID
+        assert creds.gid == AGENT_UID
+
+        claude_dir = members[".claude"]
+        assert claude_dir.mode == 0o755
+        assert claude_dir.uid == AGENT_UID
+
+    def test_claude_md_injected_from_docker_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: tmp_path / "nonexistent")
+
+        docker_dir = tmp_path / "docker"
+        docker_dir.mkdir()
+        (docker_dir / "CLAUDE.md").write_bytes(b"# Agent instructions")
+
+        config = _make_config(
+            claude_api_key="sk-test",
+            compose_file=str(docker_dir / "docker-compose.yml"),
+        )
+        container = self._capture_container()
+
+        _copy_claude_config(container, config)
+
+        content = self._get_tar_content(container, ".claude/CLAUDE.md")
+        assert content == b"# Agent instructions"
+
+
+class TestSaveClaudeCredentials:
+    """Tests for save_claude_credentials state extraction."""
+
+    def _mock_container(self, claude_files: dict[str, bytes], claude_json: bytes | None = None):
+        """Build a mock container with get_archive returning synthetic tars."""
+        container = MagicMock()
+
+        def get_archive(path):
+            if ".claude/." in path:
+                # Wrap files under .claude/ prefix (Docker get_archive behavior)
+                wrapped = {f".claude/{k}": v for k, v in claude_files.items()}
+                tar_buf = _make_tar(wrapped)
+                return iter([tar_buf.read()]), {}
+            if ".claude.json" in path:
+                if claude_json is None:
+                    import docker.errors
+                    raise docker.errors.APIError("not found")
+                tar_buf = _make_tar({".claude.json": claude_json})
+                return iter([tar_buf.read()]), {}
+            import docker.errors
+            raise docker.errors.APIError("not found")
+
+        container.get_archive = get_archive
+        return container
+
+    def test_saves_state_to_disk(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "claude-state"
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: state_dir)
+
+        container = self._mock_container(
+            {".credentials.json": b'{"creds": true}', "settings.json": b'{"s": 1}'}
+        )
+        client = MagicMock()
+        client.containers.get.return_value = container
+        monkeypatch.setattr("cc_forge.docker._docker_client", lambda: client)
+
+        save_claude_credentials("test-id")
+
+        assert (state_dir / ".credentials.json").read_bytes() == b'{"creds": true}'
+        assert (state_dir / "settings.json").read_bytes() == b'{"s": 1}'
+
+    def test_creates_state_dir_on_first_run(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "deep" / "nested" / "claude-state"
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: state_dir)
+
+        container = self._mock_container(
+            {".credentials.json": b'{"creds": true}'},
+            claude_json=b'{"hasCompletedOnboarding": true}',
+        )
+        client = MagicMock()
+        client.containers.get.return_value = container
+        monkeypatch.setattr("cc_forge.docker._docker_client", lambda: client)
+
+        assert not state_dir.exists()
+        save_claude_credentials("test-id")
+
+        assert state_dir.is_dir()
+        assert (state_dir / ".credentials.json").exists()
+        assert (state_dir / ".claude.json").read_bytes() == b'{"hasCompletedOnboarding": true}'
+
+    def test_filters_skip_patterns(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "claude-state"
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: state_dir)
+
+        container = self._mock_container({
+            ".credentials.json": b'{"creds": true}',
+            "debug/log.txt": b"debug data",
+            "session-env/env.json": b"{}",
+            "file-history/h.json": b"{}",
+            "shell-snapshots/s.json": b"{}",
+            "settings.json": b'{"keep": true}',
+        })
+        client = MagicMock()
+        client.containers.get.return_value = container
+        monkeypatch.setattr("cc_forge.docker._docker_client", lambda: client)
+
+        save_claude_credentials("test-id")
+
+        assert (state_dir / "settings.json").exists()
+        assert not (state_dir / "debug").exists()
+        assert not (state_dir / "session-env").exists()
+        assert not (state_dir / "file-history").exists()
+        assert not (state_dir / "shell-snapshots").exists()
+
+    def test_filters_git_dirs(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "claude-state"
+        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: state_dir)
+
+        container = self._mock_container({
+            ".credentials.json": b'{"creds": true}',
+            ".git/config": b"git config",
+            "projects/.git/HEAD": b"ref",
+        })
+        client = MagicMock()
+        client.containers.get.return_value = container
+        monkeypatch.setattr("cc_forge.docker._docker_client", lambda: client)
+
+        save_claude_credentials("test-id")
+
+        assert not (state_dir / ".git").exists()
+
+    def test_container_not_found_returns_silently(self, monkeypatch):
+        from docker.errors import NotFound
+
+        client = MagicMock()
+        client.containers.get.side_effect = NotFound("gone")
+        monkeypatch.setattr("cc_forge.docker._docker_client", lambda: client)
+
+        save_claude_credentials("missing-id")  # Should not raise


### PR DESCRIPTION
## Summary
Replaces `ANTHROPIC_API_KEY` env var as the only `--claude` auth path with full OAuth-credential and Claude-state persistence across sessions. The scope grew during implementation to cover the whole credential lifecycle (inject → save → reuse), not just the initial swap.

What's included:
- OAuth credentials (`.credentials.json`) injected from `~/.claude/` into the container, then saved back to `~/.config/forge/claude-state/` on exit so subsequent runs skip auth
- Full `.claude/` state directory (`projects`, `history.jsonl`, `settings.json`, etc.) persisted between sessions to skip onboarding too
- `.claude.json` (userID/account state) injected and saved
- `ANTHROPIC_API_KEY` still supported as a fallback for non-interactive use
- Settings injection skips the Claude Code onboarding prompts on first run
- Container creation split into `create` → `put_archive` → `start` so files are injected with correct ownership before the entrypoint runs
- Container auto-update disabled in the agent image
- Cleanup races handled (orphaned containers removed on config-injection failure)
- Final hardening pass: testable `_forge_claude_state_dir()` function, specific exception handling (no more bare `except Exception: pass`), missing `mkdir` fixed in `save_claude_credentials`, deduped `.credentials.json` injection

## Test plan
- [x] 49/49 unit tests passing
- [x] Tests use `tmp_path` + monkeypatch — no live credentials touched
- [x] CI green
- [x] End-to-end smoke test on tesseract: cold run (OAuth flow + state saved) and warm run (no auth, no onboarding) both pass

Closes #34