### PR TITLE
Add Forgejo-backed gh CLI shim for the agent container (MVP for #32)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -37,6 +37,11 @@ RUN sed -i 's/?beta=true//g' /usr/local/lib/node_modules/@anthropic-ai/claude-co
         exit 1; \
     fi
 
+# Forgejo-backed `gh` shim — agent reaches for `gh` by training prior;
+# this routes supported subcommands to Forgejo's REST API.
+COPY gh-shim.sh /usr/local/bin/gh
+RUN chmod +x /usr/local/bin/gh
+
 # Create non-root user (remove ubuntu default to claim UID 1000)
 RUN userdel -r ubuntu 2>/dev/null; \
     useradd -m -s /bin/bash -u 1000 agent && \

--- a/docker/gh-shim.sh
+++ b/docker/gh-shim.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Forgejo-backed `gh` CLI shim for the forge agent container.
+#
+# The agent's training prior is to reach for `gh`. We install this script as
+# /usr/local/bin/gh so that `gh pr create`, `gh issue view`, etc. translate
+# to Forgejo REST API calls instead of failing.
+#
+# Supported subcommands (allowlist):
+#   gh pr create --title T --head B [--base B] [--body B]
+#   gh pr view <number>
+#   gh issue view <number>
+#   gh issue list
+#
+# Output is the raw Forgejo API JSON. Anything outside the allowlist exits
+# with a clear message naming what's supported.
+
+set -euo pipefail
+
+die() {
+    echo "gh: $*" >&2
+    exit 1
+}
+
+require_env() {
+    [ -n "${FORGEJO_URL:-}" ] || die "FORGEJO_URL not set"
+    [ -n "${FORGEJO_TOKEN:-}" ] || die "FORGEJO_TOKEN not set"
+}
+
+# Override with FORGE_WORKSPACE for testing outside the container.
+WORKSPACE="${FORGE_WORKSPACE:-/workspace/repo}"
+
+# Derive owner/repo from the workspace origin remote.
+detect_repo() {
+    local url owner_repo
+    url=$(git -C "$WORKSPACE" remote get-url origin 2>/dev/null) \
+        || die "could not read origin remote from $WORKSPACE"
+    # Strip "<proto>://<host[:port]>/" (HTTP) or "user@host:" (SSH) prefix
+    # and ".git" suffix.
+    owner_repo=$(echo "$url" | sed -E '
+        s#^[^/]+//[^/]+/##
+        s#^[^@]+@[^:]+:##
+        s#\.git$##
+    ')
+    [ -n "$owner_repo" ] || die "could not parse owner/repo from $url"
+    echo "$owner_repo"
+}
+
+api_get() {
+    local path="$1"
+    curl -sf \
+        -H "Authorization: token $FORGEJO_TOKEN" \
+        -H "Accept: application/json" \
+        "$FORGEJO_URL/api/v1/$path"
+}
+
+api_post() {
+    local path="$1" body="$2"
+    curl -sf -X POST \
+        -H "Authorization: token $FORGEJO_TOKEN" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json" \
+        -d "$body" \
+        "$FORGEJO_URL/api/v1/$path"
+}
+
+cmd_pr_create() {
+    local title="" head="" base="main" body=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --title) title="$2"; shift 2 ;;
+            --head)  head="$2";  shift 2 ;;
+            --base)  base="$2";  shift 2 ;;
+            --body)  body="$2";  shift 2 ;;
+            *) die "unknown flag for 'pr create': $1" ;;
+        esac
+    done
+    [ -n "$title" ] || die "--title is required for 'pr create'"
+    [ -n "$head" ]  || die "--head is required for 'pr create'"
+
+    local owner_repo payload
+    owner_repo=$(detect_repo)
+    payload=$(jq -nc \
+        --arg title "$title" \
+        --arg head "$head" \
+        --arg base "$base" \
+        --arg body "$body" \
+        '{title: $title, head: $head, base: $base, body: $body}')
+    api_post "repos/$owner_repo/pulls" "$payload"
+}
+
+cmd_pr_view() {
+    local n="${1:-}"
+    [ -n "$n" ] || die "'pr view' requires a number"
+    local owner_repo
+    owner_repo=$(detect_repo)
+    api_get "repos/$owner_repo/pulls/$n"
+}
+
+cmd_issue_view() {
+    local n="${1:-}"
+    [ -n "$n" ] || die "'issue view' requires a number"
+    local owner_repo
+    owner_repo=$(detect_repo)
+    api_get "repos/$owner_repo/issues/$n"
+}
+
+cmd_issue_list() {
+    local owner_repo
+    owner_repo=$(detect_repo)
+    api_get "repos/$owner_repo/issues"
+}
+
+require_env
+
+case "${1:-}" in
+    pr)
+        case "${2:-}" in
+            create) shift 2; cmd_pr_create "$@" ;;
+            view)   shift 2; cmd_pr_view "$@" ;;
+            *) die "'pr ${2:-}' not supported; supported: pr create, pr view" ;;
+        esac
+        ;;
+    issue)
+        case "${2:-}" in
+            view) shift 2; cmd_issue_view "$@" ;;
+            list) shift 2; cmd_issue_list "$@" ;;
+            *) die "'issue ${2:-}' not supported; supported: issue view, issue list" ;;
+        esac
+        ;;
+    "") die "no subcommand; supported: pr create, pr view, issue view, issue list" ;;
+    *) die "'$1' not supported by the forge shim; supported: pr create, pr view, issue view, issue list" ;;
+esac

--- a/docker/gh-shim.sh
+++ b/docker/gh-shim.sh
@@ -64,13 +64,14 @@ api_post() {
 }
 
 cmd_pr_create() {
+    require_env
     local title="" head="" base="main" body=""
     while [ $# -gt 0 ]; do
         case "$1" in
-            --title) title="$2"; shift 2 ;;
-            --head)  head="$2";  shift 2 ;;
-            --base)  base="$2";  shift 2 ;;
-            --body)  body="$2";  shift 2 ;;
+            --title) [ $# -ge 2 ] || die "--title needs a value"; title="$2"; shift 2 ;;
+            --head)  [ $# -ge 2 ] || die "--head needs a value";  head="$2";  shift 2 ;;
+            --base)  [ $# -ge 2 ] || die "--base needs a value";  base="$2";  shift 2 ;;
+            --body)  [ $# -ge 2 ] || die "--body needs a value";  body="$2";  shift 2 ;;
             *) die "unknown flag for 'pr create': $1" ;;
         esac
     done
@@ -89,28 +90,28 @@ cmd_pr_create() {
 }
 
 cmd_pr_view() {
-    local n="${1:-}"
-    [ -n "$n" ] || die "'pr view' requires a number"
+    require_env
+    [ $# -eq 1 ] || die "'pr view' takes exactly one argument (the PR number)"
     local owner_repo
     owner_repo=$(detect_repo)
-    api_get "repos/$owner_repo/pulls/$n"
+    api_get "repos/$owner_repo/pulls/$1"
 }
 
 cmd_issue_view() {
-    local n="${1:-}"
-    [ -n "$n" ] || die "'issue view' requires a number"
+    require_env
+    [ $# -eq 1 ] || die "'issue view' takes exactly one argument (the issue number)"
     local owner_repo
     owner_repo=$(detect_repo)
-    api_get "repos/$owner_repo/issues/$n"
+    api_get "repos/$owner_repo/issues/$1"
 }
 
 cmd_issue_list() {
+    require_env
+    [ $# -eq 0 ] || die "'issue list' takes no arguments"
     local owner_repo
     owner_repo=$(detect_repo)
     api_get "repos/$owner_repo/issues"
 }
-
-require_env
 
 case "${1:-}" in
     pr)

--- a/tests/unit/test_gh_shim.py
+++ b/tests/unit/test_gh_shim.py
@@ -1,0 +1,228 @@
+"""Tests for docker/gh-shim.sh — the Forgejo-backed gh CLI shim.
+
+Each test runs the shim with a patched PATH containing a fake `curl` that
+records its argv to a log file, plus a temporary workspace git repo with a
+Forgejo-style origin. Tests assert the URL, method, and (for POSTs) body the
+shim would have sent to Forgejo.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SHIM = Path(__file__).resolve().parents[2] / "docker" / "gh-shim.sh"
+
+
+@pytest.fixture
+def fake_repo(tmp_path):
+    repo = tmp_path / "workspace" / "repo"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin",
+         "http://forge-forgejo:3000/alice/widgets.git"],
+        cwd=repo, check=True,
+    )
+    return repo
+
+
+@pytest.fixture
+def fake_curl(tmp_path):
+    """Install a fake `curl` on PATH that records argv and prints '{}'."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "curl.log"
+    fake = bin_dir / "curl"
+    fake.write_text(
+        "#!/bin/bash\n"
+        f'for a in "$@"; do printf "%s\\n" "$a"; done >> "{log}"\n'
+        "echo '{}'\n"
+    )
+    fake.chmod(0o755)
+    return bin_dir, log
+
+
+def _run(args, env, bin_dir):
+    full_env = {
+        **os.environ,
+        **env,
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+    }
+    return subprocess.run(
+        ["bash", str(SHIM), *args],
+        env=full_env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _env(fake_repo):
+    return {
+        "FORGEJO_URL": "http://forge-forgejo:3000",
+        "FORGEJO_TOKEN": "test-token",
+        "FORGE_WORKSPACE": str(fake_repo),
+    }
+
+
+class TestPrCreate:
+    def test_posts_to_pulls_endpoint_with_required_fields(self, fake_repo, fake_curl):
+        bin_dir, log = fake_curl
+        result = _run(
+            ["pr", "create", "--title", "Fix typo", "--head", "topic"],
+            _env(fake_repo),
+            bin_dir,
+        )
+        assert result.returncode == 0, result.stderr
+        logged = log.read_text()
+        assert "http://forge-forgejo:3000/api/v1/repos/alice/widgets/pulls" in logged
+        assert "POST" in logged
+        assert "Authorization: token test-token" in logged
+        assert '"title":"Fix typo"' in logged
+        assert '"head":"topic"' in logged
+        assert '"base":"main"' in logged  # default base
+
+    def test_accepts_custom_base_and_body(self, fake_repo, fake_curl):
+        bin_dir, log = fake_curl
+        result = _run(
+            ["pr", "create",
+             "--title", "T", "--head", "h", "--base", "develop", "--body", "B"],
+            _env(fake_repo),
+            bin_dir,
+        )
+        assert result.returncode == 0
+        logged = log.read_text()
+        assert '"base":"develop"' in logged
+        assert '"body":"B"' in logged
+
+    def test_missing_title_fails(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        result = _run(
+            ["pr", "create", "--head", "topic"],
+            _env(fake_repo),
+            bin_dir,
+        )
+        assert result.returncode != 0
+        assert "--title is required" in result.stderr
+
+
+class TestPrView:
+    def test_gets_pulls_by_number(self, fake_repo, fake_curl):
+        bin_dir, log = fake_curl
+        result = _run(["pr", "view", "7"], _env(fake_repo), bin_dir)
+        assert result.returncode == 0, result.stderr
+        logged = log.read_text()
+        assert "http://forge-forgejo:3000/api/v1/repos/alice/widgets/pulls/7" in logged
+
+    def test_missing_number_fails(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        result = _run(["pr", "view"], _env(fake_repo), bin_dir)
+        assert result.returncode != 0
+        assert "requires a number" in result.stderr
+
+
+class TestIssueView:
+    def test_gets_issue_by_number(self, fake_repo, fake_curl):
+        bin_dir, log = fake_curl
+        result = _run(["issue", "view", "12"], _env(fake_repo), bin_dir)
+        assert result.returncode == 0, result.stderr
+        logged = log.read_text()
+        assert (
+            "http://forge-forgejo:3000/api/v1/repos/alice/widgets/issues/12"
+            in logged
+        )
+
+
+class TestIssueList:
+    def test_lists_issues(self, fake_repo, fake_curl):
+        bin_dir, log = fake_curl
+        result = _run(["issue", "list"], _env(fake_repo), bin_dir)
+        assert result.returncode == 0, result.stderr
+        logged = log.read_text()
+        assert (
+            "http://forge-forgejo:3000/api/v1/repos/alice/widgets/issues"
+            in logged
+        )
+
+
+class TestAllowlist:
+    def test_rejects_unknown_subcommand(self, fake_repo, fake_curl):
+        bin_dir, log = fake_curl
+        result = _run(["repo", "view"], _env(fake_repo), bin_dir)
+        assert result.returncode != 0
+        assert "not supported" in result.stderr
+        assert log.exists() is False or log.read_text() == ""
+
+    def test_rejects_unknown_pr_subcommand(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        result = _run(["pr", "merge", "5"], _env(fake_repo), bin_dir)
+        assert result.returncode != 0
+        assert "not supported" in result.stderr
+
+    def test_no_subcommand_fails_with_help(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        result = _run([], _env(fake_repo), bin_dir)
+        assert result.returncode != 0
+        assert "supported" in result.stderr
+
+
+class TestEnvironment:
+    def test_missing_forgejo_url_fails(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        env = _env(fake_repo)
+        env.pop("FORGEJO_URL")
+        result = _run(["pr", "view", "1"], env, bin_dir)
+        assert result.returncode != 0
+        assert "FORGEJO_URL not set" in result.stderr
+
+    def test_missing_forgejo_token_fails(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        env = _env(fake_repo)
+        env.pop("FORGEJO_TOKEN")
+        result = _run(["pr", "view", "1"], env, bin_dir)
+        assert result.returncode != 0
+        assert "FORGEJO_TOKEN not set" in result.stderr
+
+
+class TestRepoDetection:
+    def test_parses_owner_repo_from_http_remote(self, fake_repo, fake_curl):
+        bin_dir, log = fake_curl
+        result = _run(["issue", "list"], _env(fake_repo), bin_dir)
+        assert result.returncode == 0
+        assert "/repos/alice/widgets/issues" in log.read_text()
+
+    def test_handles_ssh_style_remote(self, tmp_path, fake_curl):
+        repo = tmp_path / "ws"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin",
+             "git@forge-forgejo:bob/thing.git"],
+            cwd=repo, check=True,
+        )
+        bin_dir, log = fake_curl
+        env = {
+            "FORGEJO_URL": "http://forge-forgejo:3000",
+            "FORGEJO_TOKEN": "tok",
+            "FORGE_WORKSPACE": str(repo),
+        }
+        result = _run(["issue", "list"], env, bin_dir)
+        assert result.returncode == 0, result.stderr
+        assert "/repos/bob/thing/issues" in log.read_text()
+
+    def test_no_origin_fails_clearly(self, tmp_path, fake_curl):
+        repo = tmp_path / "ws"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        bin_dir, _ = fake_curl
+        env = {
+            "FORGEJO_URL": "http://forge-forgejo:3000",
+            "FORGEJO_TOKEN": "tok",
+            "FORGE_WORKSPACE": str(repo),
+        }
+        result = _run(["issue", "list"], env, bin_dir)
+        assert result.returncode != 0
+        assert "could not read origin remote" in result.stderr

--- a/tests/unit/test_gh_shim.py
+++ b/tests/unit/test_gh_shim.py
@@ -108,6 +108,19 @@ class TestPrCreate:
         assert result.returncode != 0
         assert "--title is required" in result.stderr
 
+    def test_flag_without_value_fails_with_arity_error(self, fake_repo, fake_curl):
+        # Last-arg flag should produce a shim error, not a bash "unbound variable"
+        # message (which set -u would emit if $2 were read unguarded).
+        bin_dir, _ = fake_curl
+        result = _run(
+            ["pr", "create", "--head", "topic", "--title"],
+            _env(fake_repo),
+            bin_dir,
+        )
+        assert result.returncode != 0
+        assert "--title needs a value" in result.stderr
+        assert "unbound variable" not in result.stderr
+
 
 class TestPrView:
     def test_gets_pulls_by_number(self, fake_repo, fake_curl):
@@ -121,7 +134,13 @@ class TestPrView:
         bin_dir, _ = fake_curl
         result = _run(["pr", "view"], _env(fake_repo), bin_dir)
         assert result.returncode != 0
-        assert "requires a number" in result.stderr
+        assert "takes exactly one argument" in result.stderr
+
+    def test_extra_args_rejected(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        result = _run(["pr", "view", "7", "--json"], _env(fake_repo), bin_dir)
+        assert result.returncode != 0
+        assert "takes exactly one argument" in result.stderr
 
 
 class TestIssueView:
@@ -135,6 +154,12 @@ class TestIssueView:
             in logged
         )
 
+    def test_extra_args_rejected(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        result = _run(["issue", "view", "12", "--web"], _env(fake_repo), bin_dir)
+        assert result.returncode != 0
+        assert "takes exactly one argument" in result.stderr
+
 
 class TestIssueList:
     def test_lists_issues(self, fake_repo, fake_curl):
@@ -147,6 +172,12 @@ class TestIssueList:
             in logged
         )
 
+    def test_any_args_rejected(self, fake_repo, fake_curl):
+        bin_dir, _ = fake_curl
+        result = _run(["issue", "list", "--state", "all"], _env(fake_repo), bin_dir)
+        assert result.returncode != 0
+        assert "takes no arguments" in result.stderr
+
 
 class TestAllowlist:
     def test_rejects_unknown_subcommand(self, fake_repo, fake_curl):
@@ -155,6 +186,18 @@ class TestAllowlist:
         assert result.returncode != 0
         assert "not supported" in result.stderr
         assert log.exists() is False or log.read_text() == ""
+
+    def test_unknown_subcommand_surfaces_allowlist_error_not_env_error(
+        self, fake_repo, fake_curl,
+    ):
+        # require_env runs inside cmd_* functions, so unsupported subcommands
+        # should report the allowlist mismatch even when env is unset.
+        bin_dir, _ = fake_curl
+        env = {"FORGE_WORKSPACE": str(fake_repo)}  # no FORGEJO_URL/TOKEN
+        result = _run(["repo", "view"], env, bin_dir)
+        assert result.returncode != 0
+        assert "not supported" in result.stderr
+        assert "FORGEJO_URL not set" not in result.stderr
 
     def test_rejects_unknown_pr_subcommand(self, fake_repo, fake_curl):
         bin_dir, _ = fake_curl


### PR DESCRIPTION
## Summary

Installs a small bash shim at `/usr/local/bin/gh` inside the agent container that translates a handful of common `gh` CLI invocations to Forgejo REST API calls. The agent's training prior is to reach for `gh`, so this routes those calls to the right backend instead of failing with "command not found."

MVP scope — covers the four subcommands the agent uses most often. Anything else exits with a clear message naming the allowlist.

## What's included

- `docker/gh-shim.sh` — bash, allowlist-only. Supported subcommands:
  - `gh pr create --title T --head B [--base B] [--body B]` → `POST /api/v1/repos/{owner}/{repo}/pulls`
  - `gh pr view <number>` → `GET .../pulls/<number>`
  - `gh issue view <number>` → `GET .../issues/<number>`
  - `gh issue list` → `GET .../issues`
  - Anything else: fail with a clear message
- `docker/Dockerfile.agent` — `COPY` the shim to `/usr/local/bin/gh` and `chmod +x`
- `tests/unit/test_gh_shim.py` — 15 tests covering each subcommand, the allowlist rejections, missing-env handling, and URL parsing for HTTP + SSH-style remotes. Tests run the shim with a PATH-mocked `curl` that records argv.

## Design notes

- Output is the raw Forgejo API JSON (no `gh`-style prettified text). Simpler for the agent to parse via `jq`; we can add prettified text later if the agent struggles with raw JSON.
- The shim reads `$FORGEJO_URL` and `$FORGEJO_TOKEN` (already set by `docker.py:run_agent_container`). Owner/repo is derived from `git remote get-url origin` in the workspace. `FORGE_WORKSPACE` overrides the workspace path for tests.
- Uses only `curl` + `jq`, both already in the agent image — no new dependencies.

## Out of scope (separate issues)

- Read-only GitHub access (#44) — extends this shim to also reach upstream GitHub.
- Agent contributions to existing upstream PRs (#45) — deferred design problem.
- Agent-facing documentation of the shim's allowlist (#30) — container CLAUDE.md.

## Test plan

- [x] 15/15 new shim tests pass; full suite 64/64 green locally
- [ ] Smoke test in a real container — requires rebuild of `cc-forge-agent:latest`. Verified shim source + Dockerfile change look right; rebuild deferred to a follow-up step on tesseract.

Closes #32 (MVP scope).