### PR TITLE
Harden agent container: resource limits, token isolation, reduced host exposure

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -48,7 +48,8 @@ USER agent
 ENV PATH="/home/agent/.local/bin:$PATH"
 RUN pipx install aider-chat
 
-# Forgejo connection (set at container launch)
+# Forgejo connection — token injected via .git-credentials, not env vars.
+# FORGEJO_URL and FORGEJO_TOKEN kept as empty defaults for manual docker run only.
 ENV FORGEJO_URL=""
 ENV FORGEJO_TOKEN=""
 ENV REPO_URL=""
@@ -63,7 +64,8 @@ ENV ANTHROPIC_BASE_URL="http://forge-ollama-proxy:11434"
 # Git configuration
 RUN git config --global user.name "Forge Agent" && \
     git config --global user.email "agent@forge.local" && \
-    git config --global init.defaultBranch main
+    git config --global init.defaultBranch main && \
+    git config --global credential.helper store
 
 WORKDIR /workspace
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:15
+    image: codeberg.org/forgejo/forgejo:14
     container_name: forge-forgejo
     restart: unless-stopped
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:14
+    image: codeberg.org/forgejo/forgejo:15
     container_name: forge-forgejo
     restart: unless-stopped
     volumes:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,7 +13,9 @@ fi
 if [ ! -f "$HOME/.git-credentials" ] && [ -n "$FORGEJO_TOKEN" ] && [ -n "$FORGEJO_URL" ]; then
     FORGEJO_PROTO=$(echo "$FORGEJO_URL" | sed 's|://.*||')
     FORGEJO_HOST=$(echo "$FORGEJO_URL" | sed 's|https\?://||' | sed 's|/.*||')
-    echo "${FORGEJO_PROTO}://forge-agent:${FORGEJO_TOKEN}@${FORGEJO_HOST}" > "$HOME/.git-credentials"
+    # Percent-encode the token so reserved chars (@ : /) don't corrupt the URL.
+    ENC_TOKEN=$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$FORGEJO_TOKEN")
+    echo "${FORGEJO_PROTO}://forge-agent:${ENC_TOKEN}@${FORGEJO_HOST}" > "$HOME/.git-credentials"
     chmod 600 "$HOME/.git-credentials"
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,16 +9,12 @@ if [ -z "$REPO_URL" ]; then
     exit 1
 fi
 
-# Configure git credential helper for token-based Forgejo auth
-if [ -n "$FORGEJO_TOKEN" ] && [ -n "$FORGEJO_URL" ]; then
-    # Extract protocol and host from FORGEJO_URL
+# Forge injects .git-credentials before start; fall back to env vars for manual runs.
+if [ ! -f "$HOME/.git-credentials" ] && [ -n "$FORGEJO_TOKEN" ] && [ -n "$FORGEJO_URL" ]; then
     FORGEJO_PROTO=$(echo "$FORGEJO_URL" | sed 's|://.*||')
     FORGEJO_HOST=$(echo "$FORGEJO_URL" | sed 's|https\?://||' | sed 's|/.*||')
-    # Write credentials file with restrictive permissions
-    CRED_FILE="$HOME/.git-credentials"
-    echo "${FORGEJO_PROTO}://forge-agent:${FORGEJO_TOKEN}@${FORGEJO_HOST}" > "$CRED_FILE"
-    chmod 600 "$CRED_FILE"
-    git config --global credential.helper "store --file=$CRED_FILE"
+    echo "${FORGEJO_PROTO}://forge-agent:${FORGEJO_TOKEN}@${FORGEJO_HOST}" > "$HOME/.git-credentials"
+    chmod 600 "$HOME/.git-credentials"
 fi
 
 echo "Cloning $REPO_URL (branch: ${REPO_BRANCH:-main})..."

--- a/docs/WORKSTATION-SETUP.md
+++ b/docs/WORKSTATION-SETUP.md
@@ -46,19 +46,21 @@ After that, `forge run --claude` from any git repo on the workstation:
 
 1. rsyncs the repo to `tesseract:~/forge-workspaces/<repo>/`,
 2. SSHes to tesseract with a TTY,
-3. invokes server-side `forge run --repo ~/forge-workspaces/<repo> --claude`.
+3. invokes server-side `forge run --repo ~/forge-workspaces/<repo> --claude`,
+4. on session end, adds a `forgejo` remote and fetches agent branches back.
 
-The agent session runs as it always did. You can review and merge the agent's
-work at `http://tesseract:3000` from the workstation's browser.
+The agent session runs as it always did. You can review the agent's work at
+`http://tesseract:3000` from the workstation's browser, and the agent's
+branches are available locally via `git branch -r | grep forgejo/`.
 
 ## Limitations
 
 - The agent works on the server-side rsync'd copy. Local uncommitted changes
-  travel via rsync (good), but the agent's commits land in Forgejo (server),
-  not in your workstation working tree. Pull from Forgejo or rsync the
-  workspace back when you want them locally.
-- Wrapper assumes the SSH alias is literally `tesseract`. If you use a
-  different host, edit the script.
+  travel via rsync (good), but the agent's commits land in Forgejo (server).
+  The wrapper auto-fetches agent branches after the session ends.
+- Override the server hostname, Forgejo user, or port via env vars:
+  `FORGE_SERVER`, `FORGE_FORGEJO_USER`, `FORGE_FORGEJO_PORT` (defaults:
+  `tesseract`, `cc_forge_admin`, `3000`).
 - Workstation `~/.config/forge/config.env` is intentionally absent — the
   workstation wrapper does not run forge locally, so it does not read config.
 

--- a/scripts/remote-forge/workstation-wrapper
+++ b/scripts/remote-forge/workstation-wrapper
@@ -49,15 +49,20 @@ if [ "$SUBCMD" = "run" ]; then
         --exclude='.venv' --exclude='node_modules' --exclude='.tmp' \
         --exclude='__pycache__' --exclude='.env*' \
         "$REPO_PATH/" "$FORGE_SERVER:forge-workspaces/$REPO_KEY_Q/"
-    ssh -t "$FORGE_SERVER" "forge run --repo \$HOME/forge-workspaces/$REPO_KEY_Q $(printf '%q ' "$@")"
+    # Don't let a non-zero session exit (agent error, Ctrl-C) skip the fetch below.
+    ssh -t "$FORGE_SERVER" "forge run --repo \$HOME/forge-workspaces/$REPO_KEY_Q $(printf '%q ' "$@")" || true
 
     # Best-effort fetch of agent's work back from Forgejo.
     FORGEJO_URL="http://${FORGE_SERVER}:${FORGE_FORGEJO_PORT}/${FORGE_FORGEJO_USER}/${REPO}.git"
-    if ! git remote get-url forgejo &>/dev/null; then
+    if ! CURRENT_URL=$(git remote get-url forgejo 2>/dev/null); then
         git remote add forgejo "$FORGEJO_URL"
         echo "forge: added 'forgejo' remote → $FORGEJO_URL" >&2
+    elif [ "$CURRENT_URL" != "$FORGEJO_URL" ]; then
+        git remote set-url forgejo "$FORGEJO_URL"
+        echo "forge: updated 'forgejo' remote → $FORGEJO_URL" >&2
     fi
-    if git fetch forgejo 2>&1 | sed 's/^/forge: /' >&2; then
+    # pipefail so the branch follows git's exit status, not sed's.
+    if (set -o pipefail; git fetch forgejo 2>&1 | sed 's/^/forge: /' >&2); then
         echo "forge: session ended. Review at http://${FORGE_SERVER}:${FORGE_FORGEJO_PORT}/${FORGE_FORGEJO_USER}/${REPO}" >&2
         echo "forge: agent branches: $(git branch -r | grep 'forgejo/' | tr -d ' ' | paste -sd', ')" >&2
     else

--- a/scripts/remote-forge/workstation-wrapper
+++ b/scripts/remote-forge/workstation-wrapper
@@ -4,9 +4,11 @@
 # the server first; other subcommands pass straight through.
 #
 # Requires:
-# - SSH access to the server (alias "tesseract" in ~/.ssh/config)
+# - SSH access to the server (default alias "tesseract" in ~/.ssh/config)
 # - Server-side forge installed (see scripts/remote-forge/server-wrapper)
-# - Hostname "tesseract" resolvable to the server (see docs/WORKSTATION-SETUP.md)
+# - Server hostname resolvable for Forgejo web UI (see docs/WORKSTATION-SETUP.md)
+#
+# Override defaults via env vars: FORGE_SERVER, FORGE_FORGEJO_USER, FORGE_FORGEJO_PORT.
 #
 # Interim setup for issue #42. Remove when forge learns to talk to a remote Forgejo.
 
@@ -37,13 +39,31 @@ if [ "$SUBCMD" = "run" ]; then
     REPO_HASH=$(printf %s "$REPO_PATH" | sha1sum | cut -c1-8)
     REPO_KEY="${REPO}-${REPO_HASH}"
     REPO_KEY_Q=$(printf %q "$REPO_KEY")
-    echo "forge: syncing $REPO to tesseract (workspace: $REPO_KEY)..." >&2
-    ssh tesseract "mkdir -p forge-workspaces/$REPO_KEY_Q"
+    FORGE_SERVER="${FORGE_SERVER:-tesseract}"
+    FORGE_FORGEJO_USER="${FORGE_FORGEJO_USER:-cc_forge_admin}"
+    FORGE_FORGEJO_PORT="${FORGE_FORGEJO_PORT:-3000}"
+
+    echo "forge: syncing $REPO to $FORGE_SERVER (workspace: $REPO_KEY)..." >&2
+    ssh "$FORGE_SERVER" "mkdir -p forge-workspaces/$REPO_KEY_Q"
     rsync -az --delete \
         --exclude='.venv' --exclude='node_modules' --exclude='.tmp' \
         --exclude='__pycache__' --exclude='.env*' \
-        "$REPO_PATH/" "tesseract:forge-workspaces/$REPO_KEY_Q/"
-    exec ssh -t tesseract "forge run --repo \$HOME/forge-workspaces/$REPO_KEY_Q $(printf '%q ' "$@")"
+        "$REPO_PATH/" "$FORGE_SERVER:forge-workspaces/$REPO_KEY_Q/"
+    ssh -t "$FORGE_SERVER" "forge run --repo \$HOME/forge-workspaces/$REPO_KEY_Q $(printf '%q ' "$@")"
+
+    # Best-effort fetch of agent's work back from Forgejo.
+    FORGEJO_URL="http://${FORGE_SERVER}:${FORGE_FORGEJO_PORT}/${FORGE_FORGEJO_USER}/${REPO}.git"
+    if ! git remote get-url forgejo &>/dev/null; then
+        git remote add forgejo "$FORGEJO_URL"
+        echo "forge: added 'forgejo' remote → $FORGEJO_URL" >&2
+    fi
+    if git fetch forgejo 2>&1 | sed 's/^/forge: /' >&2; then
+        echo "forge: session ended. Review at http://${FORGE_SERVER}:${FORGE_FORGEJO_PORT}/${FORGE_FORGEJO_USER}/${REPO}" >&2
+        echo "forge: agent branches: $(git branch -r | grep 'forgejo/' | tr -d ' ' | paste -sd', ')" >&2
+    else
+        echo "forge: could not fetch from Forgejo (is $FORGE_SERVER:$FORGE_FORGEJO_PORT reachable?)" >&2
+    fi
 else
-    exec ssh -t tesseract "forge $(printf %q "$SUBCMD") $(printf '%q ' "$@")"
+    FORGE_SERVER="${FORGE_SERVER:-tesseract}"
+    exec ssh -t "$FORGE_SERVER" "forge $(printf %q "$SUBCMD") $(printf '%q ' "$@")"
 fi

--- a/src/cc_forge/config.py
+++ b/src/cc_forge/config.py
@@ -34,6 +34,8 @@ _DEFAULTS = {
     "FORGE_CLAUDE_MODEL": "qwen3-coder-32k",
     "FORGE_CLAUDE_API_KEY": "",
     "FORGE_COMPOSE_FILE": "",
+    "FORGE_AGENT_MEM_LIMIT": "4g",
+    "FORGE_AGENT_PIDS_LIMIT": "4096",
 }
 
 _ENV_FILES = [
@@ -90,6 +92,8 @@ class ForgeConfig:
         or os.environ.get("ANTHROPIC_API_KEY", "")
     )
     compose_file: str = field(default_factory=lambda: _resolve("FORGE_COMPOSE_FILE"))
+    agent_mem_limit: str = field(default_factory=lambda: _resolve("FORGE_AGENT_MEM_LIMIT"))
+    agent_pids_limit: int = field(default_factory=lambda: int(_resolve("FORGE_AGENT_PIDS_LIMIT")))
 
 
 def load_config() -> ForgeConfig:

--- a/src/cc_forge/config.py
+++ b/src/cc_forge/config.py
@@ -79,6 +79,15 @@ def _resolve(key: str) -> str:
     return default
 
 
+def _resolve_int(key: str) -> int:
+    """Resolve an integer config value with an actionable error on bad input."""
+    raw = _resolve(key)
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"{key} must be an integer, got {raw!r}")
+
+
 @dataclass(frozen=True)
 class ForgeConfig:
     forgejo_url: str = field(default_factory=lambda: _resolve("FORGE_FORGEJO_URL"))
@@ -93,7 +102,7 @@ class ForgeConfig:
     )
     compose_file: str = field(default_factory=lambda: _resolve("FORGE_COMPOSE_FILE"))
     agent_mem_limit: str = field(default_factory=lambda: _resolve("FORGE_AGENT_MEM_LIMIT"))
-    agent_pids_limit: int = field(default_factory=lambda: int(_resolve("FORGE_AGENT_PIDS_LIMIT")))
+    agent_pids_limit: int = field(default_factory=lambda: _resolve_int("FORGE_AGENT_PIDS_LIMIT"))
 
 
 def load_config() -> ForgeConfig:

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -226,7 +226,7 @@ def _inject_git_credentials(container, config: ForgeConfig) -> None:
     """Inject git credentials into the container without exposing the token as an env var."""
     import io
     import tarfile
-    from urllib.parse import urlsplit
+    from urllib.parse import quote, urlsplit
 
     if not config.forgejo_token or not config.forgejo_url:
         return
@@ -234,7 +234,9 @@ def _inject_git_credentials(container, config: ForgeConfig) -> None:
     forgejo_url = _rewrite_url(config.forgejo_url, "forge-forgejo")
     parts = urlsplit(forgejo_url)
     # git's store helper matches on scheme + host:port; drop any path/query.
-    cred_line = f"{parts.scheme}://forge-agent:{config.forgejo_token}@{parts.netloc}\n"
+    # Percent-encode the token so reserved chars (@ : /) don't corrupt the URL.
+    token = quote(config.forgejo_token, safe="")
+    cred_line = f"{parts.scheme}://forge-agent:{token}@{parts.netloc}\n"
 
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w") as tar:

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -226,14 +226,15 @@ def _inject_git_credentials(container, config: ForgeConfig) -> None:
     """Inject git credentials into the container without exposing the token as an env var."""
     import io
     import tarfile
+    from urllib.parse import urlsplit
 
     if not config.forgejo_token or not config.forgejo_url:
         return
 
     forgejo_url = _rewrite_url(config.forgejo_url, "forge-forgejo")
-    proto = forgejo_url.split("://")[0]
-    host = forgejo_url.split("://")[1].rstrip("/")
-    cred_line = f"{proto}://forge-agent:{config.forgejo_token}@{host}\n"
+    parts = urlsplit(forgejo_url)
+    # git's store helper matches on scheme + host:port; drop any path/query.
+    cred_line = f"{parts.scheme}://forge-agent:{config.forgejo_token}@{parts.netloc}\n"
 
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w") as tar:
@@ -271,8 +272,10 @@ def run_agent_container(
     else:
         environment.update(_ollama_environment(config))
 
-    # Only expose host gateway when the agent needs Ollama on the host.
-    extra_hosts = {} if claude_passthrough else {"host.docker.internal": "host-gateway"}
+    # Only expose host gateway when the agent reaches Ollama on the host.
+    ollama_url = _rewrite_url(config.ollama_cpu_url, "host.docker.internal")
+    needs_gateway = (not claude_passthrough) and "host.docker.internal" in ollama_url
+    extra_hosts = {"host.docker.internal": "host-gateway"} if needs_gateway else {}
 
     container = client.containers.create(
         image_tag,

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -222,6 +222,26 @@ def _claude_environment(config: ForgeConfig) -> dict[str, str]:
     return env
 
 
+def _inject_git_credentials(container, config: ForgeConfig) -> None:
+    """Inject git credentials into the container without exposing the token as an env var."""
+    import io
+    import tarfile
+
+    if not config.forgejo_token or not config.forgejo_url:
+        return
+
+    forgejo_url = _rewrite_url(config.forgejo_url, "forge-forgejo")
+    proto = forgejo_url.split("://")[0]
+    host = forgejo_url.split("://")[1].rstrip("/")
+    cred_line = f"{proto}://forge-agent:{config.forgejo_token}@{host}\n"
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        _add_tar_file(tar, ".git-credentials", cred_line.encode(), mode=0o600)
+    buf.seek(0)
+    container.put_archive("/home/agent", buf)
+
+
 def run_agent_container(
     config: ForgeConfig,
     repo_url: str,
@@ -238,11 +258,9 @@ def run_agent_container(
 
     # Rewrite URLs for container network: localhost → Docker service names.
     clone_url = _rewrite_url(repo_url, "forge-forgejo")
-    forgejo_url = _rewrite_url(config.forgejo_url, "forge-forgejo")
 
+    # Token is injected via .git-credentials file, not env vars.
     environment = {
-        "FORGEJO_URL": forgejo_url,
-        "FORGEJO_TOKEN": config.forgejo_token,
         "REPO_URL": clone_url,
         "REPO_BRANCH": branch,
         "FORGE_AGENT": agent,
@@ -253,18 +271,24 @@ def run_agent_container(
     else:
         environment.update(_ollama_environment(config))
 
+    # Only expose host gateway when the agent needs Ollama on the host.
+    extra_hosts = {} if claude_passthrough else {"host.docker.internal": "host-gateway"}
+
     container = client.containers.create(
         image_tag,
         name=container_name,
         network="forge-network",
         environment=environment,
         labels={"forge.role": "agent", "forge.repo": repo_name},
-        extra_hosts={"host.docker.internal": "host-gateway"},
+        extra_hosts=extra_hosts or None,
         stdin_open=True,
         tty=True,
+        mem_limit=config.agent_mem_limit,
+        pids_limit=config.agent_pids_limit,
     )
 
     try:
+        _inject_git_credentials(container, config)
         if claude_passthrough:
             _copy_claude_config(container, config)
         container.start()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,18 @@
+"""Tests for cc_forge.config helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from cc_forge.config import _resolve_int
+
+
+def test_resolve_int_parses_valid(monkeypatch):
+    monkeypatch.setenv("FORGE_AGENT_PIDS_LIMIT", "1024")
+    assert _resolve_int("FORGE_AGENT_PIDS_LIMIT") == 1024
+
+
+def test_resolve_int_reports_bad_value(monkeypatch):
+    monkeypatch.setenv("FORGE_AGENT_PIDS_LIMIT", "lots")
+    with pytest.raises(ValueError, match="FORGE_AGENT_PIDS_LIMIT must be an integer"):
+        _resolve_int("FORGE_AGENT_PIDS_LIMIT")

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -15,6 +15,7 @@ from cc_forge.docker import (
     _claude_environment,
     _claude_credentials_path,
     _copy_claude_config,
+    _inject_git_credentials,
     _build_agent_cmd,
     save_claude_credentials,
 )
@@ -24,11 +25,13 @@ def _make_config(**kwargs) -> ForgeConfig:
     defaults = dict(
         ollama_cpu_url="http://localhost:11434",
         forgejo_url="http://localhost:3000",
-        forgejo_token="test",
+        forgejo_token="test-token",
         agent_image="test",
         claude_model="test-model",
         claude_api_key="",
         compose_file="",
+        agent_mem_limit="4g",
+        agent_pids_limit=4096,
     )
     defaults.update(kwargs)
     return ForgeConfig(**defaults)
@@ -308,6 +311,106 @@ class TestCopyClaudeConfig:
 
         content = self._get_tar_content(container, ".claude/CLAUDE.md")
         assert content == b"# Agent instructions"
+
+
+class TestInjectGitCredentials:
+    """Tests for _inject_git_credentials tar injection."""
+
+    def _capture_container(self):
+        container = MagicMock()
+        container.captured_bufs = []
+
+        def capture_put_archive(path, buf):
+            container.captured_bufs.append((path, buf))
+
+        container.put_archive = capture_put_archive
+        return container
+
+    def test_injects_credentials_file(self):
+        config = _make_config(forgejo_url="http://localhost:3000", forgejo_token="tok123")
+        container = self._capture_container()
+
+        _inject_git_credentials(container, config)
+
+        assert container.captured_bufs, "put_archive was never called"
+        _, buf = container.captured_bufs[0]
+        members = _inspect_tar(buf)
+        assert ".git-credentials" in members
+        assert members[".git-credentials"].mode == 0o600
+        assert members[".git-credentials"].uid == AGENT_UID
+
+    def test_credential_format(self):
+        config = _make_config(forgejo_url="http://localhost:3000", forgejo_token="tok123")
+        container = self._capture_container()
+
+        _inject_git_credentials(container, config)
+
+        _, buf = container.captured_bufs[0]
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            content = tar.extractfile(".git-credentials").read().decode()
+        assert "forge-agent:tok123@forge-forgejo:3000" in content
+
+    def test_skips_when_no_token(self):
+        config = _make_config(forgejo_token="")
+        container = self._capture_container()
+
+        _inject_git_credentials(container, config)
+
+        assert not container.captured_bufs
+
+
+class TestRunAgentContainer:
+    """Tests for run_agent_container configuration."""
+
+    def _run(self, claude_passthrough=False, **config_kwargs):
+        config = _make_config(**config_kwargs)
+        client = MagicMock()
+        client.images.get.return_value = True
+        container = MagicMock()
+        container.id = "test-container-id"
+        # Capture the create call
+        client.containers.create.return_value = container
+
+        with patch("cc_forge.docker._docker_client", return_value=client):
+            from cc_forge.docker import run_agent_container
+            result = run_agent_container(
+                config,
+                repo_url="http://localhost:3000/user/repo.git",
+                branch="main",
+                repo_name="repo",
+                claude_passthrough=claude_passthrough,
+            )
+        return client, container, result
+
+    def test_token_not_in_env_vars(self):
+        client, container, _ = self._run()
+        create_kwargs = client.containers.create.call_args
+        env = create_kwargs.kwargs["environment"]
+        assert "FORGEJO_TOKEN" not in env
+        assert "FORGEJO_URL" not in env
+
+    def test_resource_limits_applied(self):
+        client, _, _ = self._run(agent_mem_limit="2g", agent_pids_limit=1024)
+        create_kwargs = client.containers.create.call_args
+        assert create_kwargs.kwargs["mem_limit"] == "2g"
+        assert create_kwargs.kwargs["pids_limit"] == 1024
+
+    def test_host_gateway_present_for_ollama(self):
+        client, _, _ = self._run(claude_passthrough=False)
+        create_kwargs = client.containers.create.call_args
+        extra_hosts = create_kwargs.kwargs["extra_hosts"]
+        assert extra_hosts == {"host.docker.internal": "host-gateway"}
+
+    def test_host_gateway_absent_for_claude_passthrough(self):
+        client, _, _ = self._run(claude_passthrough=True)
+        create_kwargs = client.containers.create.call_args
+        assert create_kwargs.kwargs["extra_hosts"] is None
+
+    def test_git_credentials_injected(self):
+        _, container, _ = self._run()
+        # put_archive should be called for git credentials
+        container.put_archive.assert_called()
 
 
 class TestSaveClaudeCredentials:

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -366,6 +366,21 @@ class TestInjectGitCredentials:
             content = tar.extractfile(".git-credentials").read().decode()
         assert content.strip() == "http://forge-agent:tok123@forge-forgejo:3000"
 
+    def test_token_is_url_encoded(self):
+        # Reserved chars in the token must be percent-encoded, not embedded raw.
+        config = _make_config(
+            forgejo_url="http://localhost:3000", forgejo_token="ab/cd@ef:gh"
+        )
+        container = self._capture_container()
+
+        _inject_git_credentials(container, config)
+
+        _, buf = container.captured_bufs[0]
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            content = tar.extractfile(".git-credentials").read().decode()
+        assert "forge-agent:ab%2Fcd%40ef%3Agh@forge-forgejo:3000" in content
+
     def test_skips_when_no_token(self):
         config = _make_config(forgejo_token="")
         container = self._capture_container()

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -351,6 +351,21 @@ class TestInjectGitCredentials:
             content = tar.extractfile(".git-credentials").read().decode()
         assert "forge-agent:tok123@forge-forgejo:3000" in content
 
+    def test_credential_format_strips_path(self):
+        # A Forgejo URL with a path must not leak the path into the host segment.
+        config = _make_config(
+            forgejo_url="http://localhost:3000/forgejo", forgejo_token="tok123"
+        )
+        container = self._capture_container()
+
+        _inject_git_credentials(container, config)
+
+        _, buf = container.captured_bufs[0]
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            content = tar.extractfile(".git-credentials").read().decode()
+        assert content.strip() == "http://forge-agent:tok123@forge-forgejo:3000"
+
     def test_skips_when_no_token(self):
         config = _make_config(forgejo_token="")
         container = self._capture_container()
@@ -372,7 +387,8 @@ class TestRunAgentContainer:
         # Capture the create call
         client.containers.create.return_value = container
 
-        with patch("cc_forge.docker._docker_client", return_value=client):
+        with patch("cc_forge.docker._docker_client", return_value=client), \
+                patch("cc_forge.docker._copy_claude_config"):
             from cc_forge.docker import run_agent_container
             result = run_agent_container(
                 config,
@@ -404,6 +420,12 @@ class TestRunAgentContainer:
 
     def test_host_gateway_absent_for_claude_passthrough(self):
         client, _, _ = self._run(claude_passthrough=True)
+        create_kwargs = client.containers.create.call_args
+        assert create_kwargs.kwargs["extra_hosts"] is None
+
+    def test_host_gateway_absent_for_remote_ollama(self):
+        # Ollama on a non-local host needs no gateway mapping.
+        client, _, _ = self._run(ollama_cpu_url="http://ollama.internal:11434")
         create_kwargs = client.containers.create.call_args
         assert create_kwargs.kwargs["extra_hosts"] is None
 

--- a/tests/unit/test_workstation_wrapper.py
+++ b/tests/unit/test_workstation_wrapper.py
@@ -1,0 +1,154 @@
+"""Tests for scripts/remote-forge/workstation-wrapper.
+
+The wrapper shells out to ssh/rsync/git; these tests put shim executables on
+PATH that log their invocations and return controlled exit codes, so the
+wrapper's branching logic can be exercised without a real server or network.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WRAPPER = (
+    Path(__file__).parents[2] / "scripts" / "remote-forge" / "workstation-wrapper"
+)
+
+_SSH_SHIM = """#!/bin/bash
+echo "ssh $*" >> "$CALL_LOG"
+case "$*" in
+    *"forge run"*) exit "${SSH_RUN_RC:-0}";;
+    *) exit "${SSH_RC:-0}";;
+esac
+"""
+
+_RSYNC_SHIM = """#!/bin/bash
+echo "rsync $*" >> "$CALL_LOG"
+exit "${RSYNC_RC:-0}"
+"""
+
+_GIT_SHIM = """#!/bin/bash
+echo "git $*" >> "$CALL_LOG"
+case "$1 $2" in
+    "rev-parse --show-toplevel") echo "${FAKE_REPO_PATH:-/home/u/myrepo}"; exit 0;;
+    "remote get-url")
+        if [ -n "$GIT_HAS_REMOTE" ]; then echo "$GIT_REMOTE_URL"; exit 0; fi
+        exit 2;;
+    "fetch forgejo") exit "${GIT_FETCH_RC:-0}";;
+    "branch -r") echo "  forgejo/main"; echo "  forgejo/feature/x"; exit 0;;
+    *) exit 0;;
+esac
+"""
+
+
+@pytest.fixture()
+def shim_bin(tmp_path: Path) -> Path:
+    """Create a bin/ dir of ssh/rsync/git shims and return it."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, body in (("ssh", _SSH_SHIM), ("rsync", _RSYNC_SHIM), ("git", _GIT_SHIM)):
+        shim = bin_dir / name
+        shim.write_text(body)
+        shim.chmod(0o755)
+    return bin_dir
+
+
+def run_wrapper(shim_bin: Path, tmp_path: Path, args: list[str], **env_overrides):
+    """Run the wrapper with shims on PATH. Returns (proc, call_log_text)."""
+    call_log = tmp_path / "calls.log"
+    env = dict(os.environ)
+    env["PATH"] = f"{shim_bin}:{env['PATH']}"
+    env["CALL_LOG"] = str(call_log)
+    env.setdefault("FAKE_REPO_PATH", "/home/u/myrepo")
+    env.update(env_overrides)
+    proc = subprocess.run(
+        ["bash", str(WRAPPER), *args],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    log = call_log.read_text() if call_log.exists() else ""
+    return proc, log
+
+
+def test_rejects_user_repo_flag(shim_bin, tmp_path):
+    proc, log = run_wrapper(shim_bin, tmp_path, ["run", "--repo", "/foo"])
+    assert proc.returncode == 1
+    assert "do not pass --repo yourself" in proc.stderr
+    assert "ssh" not in log  # bailed before touching the server
+
+
+def test_syncs_then_invokes_remote_run(shim_bin, tmp_path):
+    proc, log = run_wrapper(shim_bin, tmp_path, ["run"])
+    assert proc.returncode == 0
+    assert "rsync" in log
+    assert "forge run --repo" in log
+    assert "session ended" in proc.stderr
+
+
+def test_adds_forgejo_remote_when_absent(shim_bin, tmp_path):
+    proc, log = run_wrapper(shim_bin, tmp_path, ["run"])  # GIT_HAS_REMOTE unset
+    assert "remote add forgejo http://tesseract:3000/cc_forge_admin/myrepo.git" in log
+    assert "added 'forgejo' remote" in proc.stderr
+
+
+def test_updates_forgejo_remote_when_url_differs(shim_bin, tmp_path):
+    proc, log = run_wrapper(
+        shim_bin,
+        tmp_path,
+        ["run"],
+        GIT_HAS_REMOTE="1",
+        GIT_REMOTE_URL="http://old-server:3000/cc_forge_admin/myrepo.git",
+    )
+    assert "remote set-url forgejo http://tesseract:3000/cc_forge_admin/myrepo.git" in log
+    assert "updated 'forgejo' remote" in proc.stderr
+
+
+def test_leaves_remote_when_url_matches(shim_bin, tmp_path):
+    proc, log = run_wrapper(
+        shim_bin,
+        tmp_path,
+        ["run"],
+        GIT_HAS_REMOTE="1",
+        GIT_REMOTE_URL="http://tesseract:3000/cc_forge_admin/myrepo.git",
+    )
+    assert "remote add forgejo" not in log
+    assert "remote set-url forgejo" not in log
+
+
+def test_fetch_failure_reports_unreachable(shim_bin, tmp_path):
+    proc, _ = run_wrapper(shim_bin, tmp_path, ["run"], GIT_FETCH_RC="1")
+    assert "could not fetch from Forgejo" in proc.stderr
+    assert "session ended" not in proc.stderr
+
+
+def test_fetch_runs_after_nonzero_session(shim_bin, tmp_path):
+    # A non-zero remote session exit must not skip the best-effort fetch.
+    proc, log = run_wrapper(shim_bin, tmp_path, ["run"], SSH_RUN_RC="1")
+    assert proc.returncode == 0
+    assert "git fetch forgejo" in log
+    assert "session ended" in proc.stderr
+
+
+def test_env_overrides_server_user_port(shim_bin, tmp_path):
+    proc, log = run_wrapper(
+        shim_bin,
+        tmp_path,
+        ["run"],
+        FORGE_SERVER="prod",
+        FORGE_FORGEJO_USER="bob",
+        FORGE_FORGEJO_PORT="4000",
+    )
+    assert "ssh prod" in log
+    assert "remote add forgejo http://prod:4000/bob/myrepo.git" in log
+
+
+def test_passthrough_subcommand_skips_rsync(shim_bin, tmp_path):
+    proc, log = run_wrapper(shim_bin, tmp_path, ["status"])
+    assert proc.returncode == 0
+    assert "rsync" not in log
+    assert "forge status" in log


### PR DESCRIPTION
## Summary

- **Token isolation**: Forgejo token injected via `.git-credentials` file instead of container env vars. Token no longer visible in `docker inspect`, `env`, or `/proc/*/environ`.
- **Resource limits**: Agent containers now have `mem_limit` (default 4GB) and `pids_limit` (default 4096) to prevent resource exhaustion. Configurable via `FORGE_AGENT_MEM_LIMIT` and `FORGE_AGENT_PIDS_LIMIT`.
- **Host gateway conditional**: `host.docker.internal` only exposed when the agent needs Ollama (not in `--claude` pass-through mode), reducing host attack surface.
- **Workstation wrapper**: auto-fetches agent branches from Forgejo after a session ends; reconciles the `forgejo` remote URL when env overrides change. Now covered by automated tests.

## Notes

- The token remains readable in `~/.git-credentials` inside the container since the agent needs push access. This change eliminates casual exposure, not all exposure.
- Entrypoint retains backward-compatible fallback for manual `docker run` with env vars.
- Forgejo v15 upgrade deferred to a separate PR (migration is one-way; warrants its own change + manual migration test).
- Future: carry PR metadata from Forgejo to GitHub — tracked in #48.

## Test plan

- [x] Unit tests pass, including new coverage for token isolation, resource limits, host-gateway branches, and the workstation wrapper
- [ ] Manual test: `forge run` with Ollama backend — verify container has host gateway and resource limits
- [ ] Manual test: `forge run --claude` — verify no host gateway, token not in `docker inspect` env
