### PR TITLE
Add forge promote: open a GitHub PR from a Forgejo PR

### DIFF
--- a/src/cc_forge/cli.py
+++ b/src/cc_forge/cli.py
@@ -39,6 +39,21 @@ def run(repo: str, agent: str, claude_passthrough: bool) -> None:
 
 
 @main.command()
+@click.argument("pr", type=int)
+@click.option("--repo", default=".", help="Path to git repository (default: current directory).")
+@click.option("--remote", default="origin",
+              help="Git remote pointing at the GitHub destination (default: origin).")
+def promote(pr: int, repo: str, remote: str) -> None:
+    """Promote a Forgejo PR to a GitHub PR."""
+    from cc_forge.config import load_config
+    from cc_forge.promote import promote_pull_request
+
+    cfg = load_config()
+    url = promote_pull_request(cfg, pr, repo_path=repo, remote=remote)
+    click.echo(url)
+
+
+@main.command()
 def status() -> None:
     """Show running forge sessions."""
     from cc_forge.docker import list_forge_containers

--- a/src/cc_forge/config.py
+++ b/src/cc_forge/config.py
@@ -116,7 +116,8 @@ class ForgeConfig:
         FORGE_GITHUB_REPO (explicit owner/repo) > FORGE_GITHUB_OWNER + repo_name > error.
         """
         if self.github_repo:
-            if "/" not in self.github_repo:
+            parts = self.github_repo.split("/")
+            if len(parts) != 2 or not all(parts):
                 raise ValueError(
                     f"FORGE_GITHUB_REPO must be 'owner/repo', got {self.github_repo!r}"
                 )

--- a/src/cc_forge/config.py
+++ b/src/cc_forge/config.py
@@ -110,6 +110,23 @@ class ForgeConfig:
     agent_mem_limit: str = field(default_factory=lambda: _resolve("FORGE_AGENT_MEM_LIMIT"))
     agent_pids_limit: int = field(default_factory=lambda: _resolve_int("FORGE_AGENT_PIDS_LIMIT"))
 
+    def resolve_github_repo(self, repo_name: str) -> str:
+        """Resolve the GitHub 'owner/repo' destination, mirroring the gh-shim chain.
+
+        FORGE_GITHUB_REPO (explicit owner/repo) > FORGE_GITHUB_OWNER + repo_name > error.
+        """
+        if self.github_repo:
+            if "/" not in self.github_repo:
+                raise ValueError(
+                    f"FORGE_GITHUB_REPO must be 'owner/repo', got {self.github_repo!r}"
+                )
+            return self.github_repo
+        if self.github_owner:
+            return f"{self.github_owner}/{repo_name}"
+        raise ValueError(
+            "Cannot resolve GitHub repo: set FORGE_GITHUB_REPO or FORGE_GITHUB_OWNER."
+        )
+
 
 def load_config() -> ForgeConfig:
     return ForgeConfig()

--- a/src/cc_forge/forgejo.py
+++ b/src/cc_forge/forgejo.py
@@ -77,3 +77,8 @@ class ForgejoClient:
         """Return the HTTP clone URL for a repository."""
         resp = self._request("GET", f"/repos/{owner}/{repo}")
         return resp.json()["clone_url"]
+
+    def get_pull_request(self, owner: str, repo: str, index: int) -> dict:
+        """Fetch a pull request's metadata (head/base refs, title, body, url)."""
+        resp = self._request("GET", f"/repos/{owner}/{repo}/pulls/{index}")
+        return resp.json()

--- a/src/cc_forge/git.py
+++ b/src/cc_forge/git.py
@@ -64,8 +64,9 @@ def add_remote(path: str | Path, name: str, url: str) -> None:
     _run(["remote", "add", name, url], cwd=path)
 
 
-def push_to_remote(path: str | Path, remote: str, branch: str) -> None:
-    _run(["push", "-u", remote, branch], cwd=path)
+def push_to_remote(path: str | Path, remote: str, branch: str, set_upstream: bool = True) -> None:
+    args = ["push", "-u", remote, branch] if set_upstream else ["push", remote, branch]
+    _run(args, cwd=path)
 
 
 def set_remote_url(path: str | Path, name: str, url: str) -> None:

--- a/src/cc_forge/git.py
+++ b/src/cc_forge/git.py
@@ -74,3 +74,12 @@ def set_remote_url(path: str | Path, name: str, url: str) -> None:
 
 def get_remote_url(path: str | Path, name: str) -> str:
     return _run(["remote", "get-url", name], cwd=path)
+
+
+def fetch_remote(path: str | Path, remote: str) -> None:
+    _run(["fetch", remote], cwd=path)
+
+
+def create_branch_from_ref(path: str | Path, branch: str, start_ref: str) -> None:
+    """Create (or reset) a local branch pointing at start_ref."""
+    _run(["branch", "-f", branch, start_ref], cwd=path)

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -13,10 +13,12 @@ from cc_forge.forgejo import ForgejoClient
 from cc_forge.git import (
     create_branch_from_ref,
     fetch_remote,
+    get_current_branch,
     get_remote_url,
     get_repo_name,
     get_repo_root,
     has_remote,
+    is_git_repo,
     push_to_remote,
 )
 
@@ -31,6 +33,9 @@ def promote_pull_request(
 
     Returns the URL of the created GitHub PR.
     """
+    if not is_git_repo(repo_path):
+        raise click.ClickException(f"{repo_path} is not a git repository.")
+
     repo_root = get_repo_root(repo_path)
     repo_name = get_repo_name(repo_root)
     github_repo = config.resolve_github_repo(repo_name)
@@ -50,20 +55,40 @@ def promote_pull_request(
             "(the workstation wrapper adds it)."
         )
     fetch_remote(repo_root, "forgejo")
+    if get_current_branch(repo_root) == head:
+        raise click.ClickException(
+            f"Branch '{head}' is currently checked out; switch to another branch "
+            "before promoting."
+        )
     create_branch_from_ref(repo_root, head, f"forgejo/{head}")
 
     if not has_remote(repo_root, remote):
         raise click.ClickException(f"No '{remote}' remote to push to.")
     _warn_on_repo_mismatch(repo_root, remote, github_repo)
-    push_to_remote(repo_root, remote, head)
+    push_to_remote(repo_root, remote, head, set_upstream=False)
 
     return _gh_pr_create(config, repo_root, github_repo, head, base, title, body)
+
+
+def _remote_owner_repo(url: str) -> str | None:
+    """Extract 'owner/repo' from an https or ssh git remote URL."""
+    url = url.rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+    # https://host/owner/repo and ssh://git@host/owner/repo carry "://";
+    # the scp form git@host:owner/repo does not.
+    tail = url.split("://", 1)[1] if "://" in url else url.split(":", 1)[-1]
+    segments = tail.split("/")
+    if len(segments) >= 2 and segments[-1] and segments[-2]:
+        return f"{segments[-2]}/{segments[-1]}"
+    return None
 
 
 def _warn_on_repo_mismatch(repo_root: Path, remote: str, github_repo: str) -> None:
     """Warn loudly if the push remote's URL doesn't match the resolved GitHub repo."""
     url = get_remote_url(repo_root, remote)
-    if github_repo not in url:
+    actual = _remote_owner_repo(url)
+    if actual is None or actual.lower() != github_repo.lower():
         click.echo(
             f"Warning: remote '{remote}' ({url}) does not match the resolved "
             f"GitHub repo '{github_repo}'. Pushing there anyway.",
@@ -86,13 +111,11 @@ def _gh_pr_create(
     if config.github_token and not _has_ambient_gh_auth(env):
         env["GH_TOKEN"] = config.github_token
 
-    result = subprocess.run(
-        ["gh", "pr", "create", "-R", github_repo,
+    result = _run_gh(
+        ["pr", "create", "-R", github_repo,
          "--head", head, "--base", base,
          "--title", title, "--body", body],
         cwd=repo_root,
-        capture_output=True,
-        text=True,
         env=env,
     )
     if result.returncode != 0:
@@ -100,8 +123,18 @@ def _gh_pr_create(
     return result.stdout.strip()
 
 
+def _run_gh(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Run a gh command, surfacing a clean error if gh isn't installed."""
+    try:
+        return subprocess.run(
+            ["gh", *args], capture_output=True, text=True, **kwargs
+        )
+    except FileNotFoundError:
+        raise click.ClickException(
+            "gh CLI not found. Install GitHub CLI (https://cli.github.com) "
+            "and authenticate with 'gh auth login'."
+        )
+
+
 def _has_ambient_gh_auth(env: dict[str, str]) -> bool:
-    result = subprocess.run(
-        ["gh", "auth", "status"], capture_output=True, text=True, env=env
-    )
-    return result.returncode == 0
+    return _run_gh(["auth", "status"], env=env).returncode == 0

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -1,0 +1,107 @@
+"""Promote a Forgejo PR to a GitHub PR (the deliberate Forgejo→GitHub hop)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import click
+
+from cc_forge.config import ForgeConfig
+from cc_forge.forgejo import ForgejoClient
+from cc_forge.git import (
+    create_branch_from_ref,
+    fetch_remote,
+    get_remote_url,
+    get_repo_name,
+    get_repo_root,
+    has_remote,
+    push_to_remote,
+)
+
+
+def promote_pull_request(
+    config: ForgeConfig,
+    pr_number: int,
+    repo_path: str = ".",
+    remote: str = "origin",
+) -> str:
+    """Materialize a Forgejo PR's branch on the GitHub remote and open a GitHub PR.
+
+    Returns the URL of the created GitHub PR.
+    """
+    repo_root = get_repo_root(repo_path)
+    repo_name = get_repo_name(repo_root)
+    github_repo = config.resolve_github_repo(repo_name)
+
+    with ForgejoClient(config) as forgejo:
+        owner = forgejo.get_current_user()
+        pr = forgejo.get_pull_request(owner, repo_name, pr_number)
+
+    head = pr["head"]["ref"]
+    base = pr["base"]["ref"]
+    title = pr["title"]
+    body = pr.get("body") or ""
+
+    if not has_remote(repo_root, "forgejo"):
+        raise click.ClickException(
+            "No 'forgejo' remote found. Run a forge session first "
+            "(the workstation wrapper adds it)."
+        )
+    fetch_remote(repo_root, "forgejo")
+    create_branch_from_ref(repo_root, head, f"forgejo/{head}")
+
+    if not has_remote(repo_root, remote):
+        raise click.ClickException(f"No '{remote}' remote to push to.")
+    _warn_on_repo_mismatch(repo_root, remote, github_repo)
+    push_to_remote(repo_root, remote, head)
+
+    return _gh_pr_create(config, repo_root, github_repo, head, base, title, body)
+
+
+def _warn_on_repo_mismatch(repo_root: Path, remote: str, github_repo: str) -> None:
+    """Warn loudly if the push remote's URL doesn't match the resolved GitHub repo."""
+    url = get_remote_url(repo_root, remote)
+    if github_repo not in url:
+        click.echo(
+            f"Warning: remote '{remote}' ({url}) does not match the resolved "
+            f"GitHub repo '{github_repo}'. Pushing there anyway.",
+            err=True,
+        )
+
+
+def _gh_pr_create(
+    config: ForgeConfig,
+    repo_root: Path,
+    github_repo: str,
+    head: str,
+    base: str,
+    title: str,
+    body: str,
+) -> str:
+    """Create a GitHub PR via the gh CLI; return its URL."""
+    env = os.environ.copy()
+    # Prefer the human's ambient gh auth; fall back to the configured token.
+    if config.github_token and not _has_ambient_gh_auth(env):
+        env["GH_TOKEN"] = config.github_token
+
+    result = subprocess.run(
+        ["gh", "pr", "create", "-R", github_repo,
+         "--head", head, "--base", base,
+         "--title", title, "--body", body],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise click.ClickException(f"gh pr create failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _has_ambient_gh_auth(env: dict[str, str]) -> bool:
+    result = subprocess.run(
+        ["gh", "auth", "status"], capture_output=True, text=True, env=env
+    )
+    return result.returncode == 0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from cc_forge.config import _resolve_int
+from cc_forge.config import ForgeConfig, _resolve_int
 
 
 def test_resolve_int_parses_valid(monkeypatch):
@@ -16,3 +16,25 @@ def test_resolve_int_reports_bad_value(monkeypatch):
     monkeypatch.setenv("FORGE_AGENT_PIDS_LIMIT", "lots")
     with pytest.raises(ValueError, match="FORGE_AGENT_PIDS_LIMIT must be an integer"):
         _resolve_int("FORGE_AGENT_PIDS_LIMIT")
+
+
+def test_resolve_github_repo_explicit_wins():
+    cfg = ForgeConfig(github_repo="owner/explicit", github_owner="someone")
+    assert cfg.resolve_github_repo("myrepo") == "owner/explicit"
+
+
+def test_resolve_github_repo_owner_plus_basename():
+    cfg = ForgeConfig(github_owner="amc-corey-cox", github_repo="")
+    assert cfg.resolve_github_repo("cc_forge") == "amc-corey-cox/cc_forge"
+
+
+def test_resolve_github_repo_rejects_bare_repo():
+    cfg = ForgeConfig(github_repo="not-owner-slash-repo")
+    with pytest.raises(ValueError, match="owner/repo"):
+        cfg.resolve_github_repo("myrepo")
+
+
+def test_resolve_github_repo_unset_errors():
+    cfg = ForgeConfig(github_repo="", github_owner="")
+    with pytest.raises(ValueError, match="FORGE_GITHUB_REPO or FORGE_GITHUB_OWNER"):
+        cfg.resolve_github_repo("myrepo")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -34,6 +34,18 @@ def test_resolve_github_repo_rejects_bare_repo():
         cfg.resolve_github_repo("myrepo")
 
 
+def test_resolve_github_repo_rejects_too_many_segments():
+    cfg = ForgeConfig(github_repo="owner/repo/extra")
+    with pytest.raises(ValueError, match="owner/repo"):
+        cfg.resolve_github_repo("myrepo")
+
+
+def test_resolve_github_repo_rejects_empty_segment():
+    cfg = ForgeConfig(github_repo="/repo")
+    with pytest.raises(ValueError, match="owner/repo"):
+        cfg.resolve_github_repo("myrepo")
+
+
 def test_resolve_github_repo_unset_errors():
     cfg = ForgeConfig(github_repo="", github_owner="")
     with pytest.raises(ValueError, match="FORGE_GITHUB_REPO or FORGE_GITHUB_OWNER"):

--- a/tests/unit/test_forgejo.py
+++ b/tests/unit/test_forgejo.py
@@ -102,3 +102,19 @@ def test_error_on_auth_failure(client: ForgejoClient, httpx_mock) -> None:
     )
     with pytest.raises(ForgejoError, match="401"):
         client.get_current_user()
+
+
+def test_get_pull_request(client: ForgejoClient, httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="http://localhost:3000/api/v1/repos/admin/myrepo/pulls/7",
+        json={
+            "title": "Add feature",
+            "body": "Does the thing.",
+            "head": {"ref": "agent/feature"},
+            "base": {"ref": "main"},
+        },
+    )
+    pr = client.get_pull_request("admin", "myrepo", 7)
+    assert pr["head"]["ref"] == "agent/feature"
+    assert pr["base"]["ref"] == "main"
+    assert pr["title"] == "Add feature"

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -41,11 +41,14 @@ def _fake_forgejo(pr: dict) -> MagicMock:
 
 
 def _wire(monkeypatch, *, remote_url="https://github.com/me/cc_forge.git",
-          has_forgejo=True, gh_rc=0, gh_stdout="https://github.com/me/cc_forge/pull/3\n",
-          gh_stderr="", captured=None):
+          has_forgejo=True, current_branch="main", is_repo=True, gh_missing=False,
+          gh_rc=0, gh_stdout="https://github.com/me/cc_forge/pull/3\n", gh_stderr="",
+          captured=None):
     captured = captured if captured is not None else {}
+    monkeypatch.setattr(promote_mod, "is_git_repo", lambda p: is_repo)
     monkeypatch.setattr(promote_mod, "get_repo_root", lambda p: Path("/repo"))
     monkeypatch.setattr(promote_mod, "get_repo_name", lambda p: "cc_forge")
+    monkeypatch.setattr(promote_mod, "get_current_branch", lambda root: current_branch)
     monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: _fake_forgejo(PR))
     monkeypatch.setattr(promote_mod, "has_remote",
                         lambda root, name: has_forgejo if name == "forgejo" else True)
@@ -53,10 +56,15 @@ def _wire(monkeypatch, *, remote_url="https://github.com/me/cc_forge.git",
     monkeypatch.setattr(promote_mod, "create_branch_from_ref",
                         lambda root, b, s: captured.update(branch=b, start=s))
     monkeypatch.setattr(promote_mod, "get_remote_url", lambda root, name: remote_url)
-    monkeypatch.setattr(promote_mod, "push_to_remote",
-                        lambda root, remote, branch: captured.update(push_remote=remote, push_branch=branch))
+
+    def fake_push(root, remote, branch, set_upstream=True):
+        captured.update(push_remote=remote, push_branch=branch, push_set_upstream=set_upstream)
+
+    monkeypatch.setattr(promote_mod, "push_to_remote", fake_push)
 
     def fake_run(args, **kwargs):
+        if gh_missing:
+            raise FileNotFoundError("gh")
         captured["gh_args"] = args
         return MagicMock(returncode=gh_rc, stdout=gh_stdout, stderr=gh_stderr)
 
@@ -73,6 +81,7 @@ def test_promote_happy_path(monkeypatch):
     assert captured["start"] == "forgejo/agent/feature"
     assert captured["push_remote"] == "origin"
     assert captured["push_branch"] == "agent/feature"
+    assert captured["push_set_upstream"] is False
 
     args = captured["gh_args"]
     assert args[:3] == ["gh", "pr", "create"]
@@ -90,6 +99,13 @@ def test_promote_warns_on_remote_mismatch(monkeypatch, capsys):
     assert "me/cc_forge" in err
 
 
+def test_promote_warns_on_substring_remote(monkeypatch, capsys):
+    # A fork whose URL *contains* the resolved repo as a substring must still warn.
+    _wire(monkeypatch, remote_url="https://github.com/me/cc_forge-fork.git")
+    promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+    assert "does not match" in capsys.readouterr().err
+
+
 def test_promote_errors_without_forgejo_remote(monkeypatch):
     _wire(monkeypatch, has_forgejo=False)
     with pytest.raises(click.ClickException, match="forgejo"):
@@ -100,3 +116,31 @@ def test_promote_errors_when_gh_fails(monkeypatch):
     _wire(monkeypatch, gh_rc=1, gh_stdout="", gh_stderr="boom")
     with pytest.raises(click.ClickException, match="gh pr create failed"):
         promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+
+
+def test_promote_errors_when_not_git_repo(monkeypatch):
+    _wire(monkeypatch, is_repo=False)
+    with pytest.raises(click.ClickException, match="not a git repository"):
+        promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+
+
+def test_promote_errors_when_head_checked_out(monkeypatch):
+    _wire(monkeypatch, current_branch="agent/feature")
+    with pytest.raises(click.ClickException, match="currently checked out"):
+        promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+
+
+def test_promote_errors_when_gh_missing(monkeypatch):
+    _wire(monkeypatch, gh_missing=True)
+    with pytest.raises(click.ClickException, match="gh CLI not found"):
+        promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+
+
+@pytest.mark.parametrize("url,expected", [
+    ("https://github.com/me/cc_forge.git", "me/cc_forge"),
+    ("https://github.com/me/cc_forge", "me/cc_forge"),
+    ("git@github.com:me/cc_forge.git", "me/cc_forge"),
+    ("ssh://git@github.com/me/cc_forge.git", "me/cc_forge"),
+])
+def test_remote_owner_repo(url, expected):
+    assert promote_mod._remote_owner_repo(url) == expected

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -1,0 +1,102 @@
+"""Tests for cc_forge.promote orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import click
+import pytest
+
+from cc_forge import promote as promote_mod
+from cc_forge.config import ForgeConfig
+
+PR = {
+    "title": "Add feature",
+    "body": "Body.",
+    "head": {"ref": "agent/feature"},
+    "base": {"ref": "main"},
+}
+
+
+def _config(**kw) -> ForgeConfig:
+    defaults = dict(
+        forgejo_url="http://localhost:3000",
+        forgejo_token="t",
+        github_owner="me",
+        github_repo="",
+        github_token="",
+    )
+    defaults.update(kw)
+    return ForgeConfig(**defaults)
+
+
+def _fake_forgejo(pr: dict) -> MagicMock:
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+    client.get_current_user.return_value = "admin"
+    client.get_pull_request.return_value = pr
+    return client
+
+
+def _wire(monkeypatch, *, remote_url="https://github.com/me/cc_forge.git",
+          has_forgejo=True, gh_rc=0, gh_stdout="https://github.com/me/cc_forge/pull/3\n",
+          gh_stderr="", captured=None):
+    captured = captured if captured is not None else {}
+    monkeypatch.setattr(promote_mod, "get_repo_root", lambda p: Path("/repo"))
+    monkeypatch.setattr(promote_mod, "get_repo_name", lambda p: "cc_forge")
+    monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: _fake_forgejo(PR))
+    monkeypatch.setattr(promote_mod, "has_remote",
+                        lambda root, name: has_forgejo if name == "forgejo" else True)
+    monkeypatch.setattr(promote_mod, "fetch_remote", lambda root, remote: None)
+    monkeypatch.setattr(promote_mod, "create_branch_from_ref",
+                        lambda root, b, s: captured.update(branch=b, start=s))
+    monkeypatch.setattr(promote_mod, "get_remote_url", lambda root, name: remote_url)
+    monkeypatch.setattr(promote_mod, "push_to_remote",
+                        lambda root, remote, branch: captured.update(push_remote=remote, push_branch=branch))
+
+    def fake_run(args, **kwargs):
+        captured["gh_args"] = args
+        return MagicMock(returncode=gh_rc, stdout=gh_stdout, stderr=gh_stderr)
+
+    monkeypatch.setattr(promote_mod.subprocess, "run", fake_run)
+    return captured
+
+
+def test_promote_happy_path(monkeypatch):
+    captured = _wire(monkeypatch)
+    url = promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+
+    assert url == "https://github.com/me/cc_forge/pull/3"
+    assert captured["branch"] == "agent/feature"
+    assert captured["start"] == "forgejo/agent/feature"
+    assert captured["push_remote"] == "origin"
+    assert captured["push_branch"] == "agent/feature"
+
+    args = captured["gh_args"]
+    assert args[:3] == ["gh", "pr", "create"]
+    assert "me/cc_forge" in args  # -R target
+    assert args[args.index("--head") + 1] == "agent/feature"
+    assert args[args.index("--base") + 1] == "main"
+    assert args[args.index("--title") + 1] == "Add feature"
+
+
+def test_promote_warns_on_remote_mismatch(monkeypatch, capsys):
+    _wire(monkeypatch, remote_url="https://github.com/other/repo.git")
+    promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+    err = capsys.readouterr().err
+    assert "does not match" in err
+    assert "me/cc_forge" in err
+
+
+def test_promote_errors_without_forgejo_remote(monkeypatch):
+    _wire(monkeypatch, has_forgejo=False)
+    with pytest.raises(click.ClickException, match="forgejo"):
+        promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+
+
+def test_promote_errors_when_gh_fails(monkeypatch):
+    _wire(monkeypatch, gh_rc=1, gh_stdout="", gh_stderr="boom")
+    with pytest.raises(click.ClickException, match="gh pr create failed"):
+        promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")


### PR DESCRIPTION
## Summary

Adds `forge promote <pr>` — the deliberate Forgejo→GitHub hop that gets an agent session's output out of the Forgejo workspace and onto GitHub as a real PR. First cut of #48.

The agent works entirely in the Forgejo workspace (the `gh` shim routes `gh pr create` there). `forge promote` runs on the workstation and carries an approved Forgejo PR up to GitHub: it materializes the PR's head branch locally, pushes it to the GitHub remote, and opens a GitHub PR with the carried title/body/base.

## Behavior

`forge promote <pr> [--repo .] [--remote origin]`:

1. Resolve the GitHub destination via the #50 chain — `FORGE_GITHUB_REPO` > `FORGE_GITHUB_OWNER` + Forgejo repo basename → error.
2. Read the Forgejo PR (head ref, base ref, title, body) via the Forgejo API.
3. Fetch the `forgejo` remote and materialize the head branch locally.
4. Push it to the remote matching the resolved `owner/repo` (default `origin`); **warn loudly on mismatch** rather than pushing to the wrong place.
5. `gh pr create -R owner/repo --head <head> --base <base> --title --body` → print the GitHub PR URL.

**Auth:** uses the human's ambient `gh` auth on the workstation; falls back to `FORGE_GITHUB_TOKEN` via `GH_TOKEN` only if ambient auth is absent.

## What's included

- `forgejo.py` — `get_pull_request(owner, repo, index)`
- `config.py` — `ForgeConfig.resolve_github_repo(repo_name)` mirroring the gh-shim resolution chain
- `git.py` — `fetch_remote`, `create_branch_from_ref`
- `promote.py` (new) — orchestration
- `cli.py` — `forge promote` subcommand
- Tests — Forgejo client method, resolver chain (4 cases), and the promote flow (happy path, remote mismatch, missing `forgejo` remote, `gh` failure)

## Deferred (per #48)

- Inferring the session's PR (MVP takes an explicit number)
- Base branch assumed to exist on GitHub (≈ always `main`)
- Multi-PR per session

## Test plan

- [x] 122 unit tests pass (mocked Forgejo + git + `gh`)
- [ ] Live end-to-end: `forge promote` against a real Forgejo PR + GitHub (mocks can't cover `gh pr create -R --head` behavior on the real remote)

Part of #48.
