### PR TITLE
Track 1 eval harness with documented cold/warm cost model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ temp/
 # Archives (keep the old_issues.txt though)
 !archive/old_issues.txt
 docs/HOME-SERVER-STATUS.md
+eval-results/

--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -1,0 +1,35 @@
+# Claude Code with Local Ollama Models
+
+How Claude Code performs against local Ollama models, and which ones we recommend. Part of the [Track 1 evaluation](https://github.com/amc-corey-cox/cc_forge/issues) of the agent-architecture exploration.
+
+> **Status:** Initial cost-model captured (see below). Matrix results pending the first evaluation pass.
+
+## Headline cost model
+
+Performance has a sharp two-mode profile:
+
+- **First call to a model:** ~25-30 minutes wall-clock on CPU, regardless of how short the prompt is. ~95% of that is Claude Code's large invariant system prompt being prefilled through the model.
+- **Subsequent calls to the same model:** seconds for short responses, dominated by output generation rate (~0.5 tok/sec on CPU). Ollama's KV cache reuses the system-prompt prefix.
+
+Practical implication: a forge session against a fresh local model will appear hung for ~25 minutes on the first prompt. After that, it behaves like a normal CPU-inference session.
+
+Full mechanism, decomposition, empirical measurements, and operational consequences are documented in [`scripts/eval/README.md`](../scripts/eval/README.md) — that's where the eval harness lives and where this understanding is canonically maintained.
+
+## Running an eval matrix
+
+See `scripts/eval/README.md` for the harness invocation. Output lands in `eval-results/<run-id>/`.
+
+## Results
+
+_Will be populated after the first matrix pass. Until then, no recommendation — use `qwen3-coder-32k` as the dogfood default (current `FORGE_CLAUDE_MODEL` default in `config.py`)._
+
+## Pre-flight requirements (run on the forge host)
+
+Before running an eval pass:
+
+- Ollama is reachable on a docker-bridge-accessible interface (not localhost-only). See the [Ollama systemd notes](LOCAL-OLLAMA-SETUP.md#stock-ollamaservice-reactivation-after-upgrades) — a stock `ollama.service` taking over port 11434 silently breaks this.
+- The agent image is built (`docker images cc-forge-agent:latest`).
+- The `forge-network` exists and `forge-ollama-proxy` is running.
+- The candidate models are pulled (`ollama list` should include each).
+
+Eventually [`forge doctor`](https://github.com/amc-corey-cox/cc_forge/issues/57) will check these automatically.

--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -27,7 +27,7 @@ _Will be populated after the first matrix pass. Until then, no recommendation �
 
 Before running an eval pass:
 
-- Ollama is reachable on a docker-bridge-accessible interface (not localhost-only). See the [Ollama systemd notes](LOCAL-OLLAMA-SETUP.md#stock-ollamaservice-reactivation-after-upgrades) — a stock `ollama.service` taking over port 11434 silently breaks this.
+- Ollama is reachable on a docker-bridge-accessible interface (not localhost-only). See [`LOCAL-OLLAMA-SETUP.md`](LOCAL-OLLAMA-SETUP.md) — a stock `ollama.service` taking over port 11434 silently breaks this.
 - The agent image is built (`docker images cc-forge-agent:latest`).
 - The `forge-network` exists and `forge-ollama-proxy` is running.
 - The candidate models are pulled (`ollama list` should include each).

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -1,0 +1,104 @@
+# Eval Harness
+
+Scripts for running the Track 1 evaluation matrix (Claude Code harness with local Ollama models). Output goes to `eval-results/<run-id>/` for later analysis.
+
+## Running
+
+```bash
+# From a forge host (tesseract):
+MODELS="qwen3-coder-32k gpt-oss:20b" \
+OLLAMA_URL="http://forge-ollama-proxy:11434" \
+./scripts/eval/run-matrix.sh
+```
+
+Required: agent image present (`cc-forge-agent:latest`), `forge-network` exists, Ollama reachable at the URL, all the named models pulled.
+
+To run a single task without the warmup orchestration (useful for debugging):
+
+```bash
+OUTPUT_BASE="eval-results/debug" \
+./scripts/eval/run-task.sh qwen3-coder-32k scripts/eval/tasks/01-sanity-pong
+```
+
+## Output structure
+
+```
+eval-results/<run-id>/
+├── _warmup/
+│   └── <model>/
+│       ├── output.json     # The warmup probe's full claude -p response
+│       └── stderr.log
+└── <model>/
+    └── <task>/
+        ├── prompt.txt      # Copy of the task's prompt for context
+        ├── output.json     # Full claude -p response (parse with jq)
+        ├── stderr.log      # Anything claude or docker wrote to stderr
+        └── meta.json       # {model, task, duration_s, ollama_url, timestamp}
+```
+
+## Tasks
+
+A task is just a directory under `scripts/eval/tasks/<NN-name>/` containing:
+
+- `prompt.txt` — the user message sent to `claude -p`
+- `expect.md` — human-readable success criteria for grading the run
+
+Tasks are run in lexical order. Prefix names with `01-`, `02-`, etc. to control ordering.
+
+`01-sanity-pong/` is provided as the minimal smoke task — it validates the harness works end-to-end and produces ~3 tokens of output, so it finishes fast even with a fully cold model. Add real tasks as separate directories.
+
+---
+
+## Cost model — why the harness is shaped the way it is
+
+Running Claude Code (`claude -p ...`) against a local Ollama model on CPU has a sharp two-mode performance profile that drives every design choice in this harness.
+
+### First call to a model: ~25-30 minutes
+
+For any prompt, even a trivial one expecting 3 tokens of output, the first invocation against a fresh Ollama process takes 25-30 minutes on CPU. Decomposition:
+
+| Phase | Approx duration | What's happening |
+|------|-----------------|------------------|
+| Model load | ~1 min | 17GB model weights read from disk into RAM |
+| **Prefill of Claude Code's system prompt** | **~25-27 min** | Claude Code sends a multi-thousand-token system prompt (tool definitions, agent loop machinery) on every call. Processing those tokens through a 17B-class model on CPU at ~5 tok/sec dominates wall-clock time. |
+| Generation | ~5-10 sec | Actual response generation (~0.5 tok/sec on CPU) |
+
+This is **not** a hardware diagnosis. The ratio of first-call-cost to warm-call-cost stays huge on any CPU-bound setup. A faster CPU reduces both proportionally.
+
+### Subsequent calls to the same model: 3-7 seconds for short responses
+
+After the first call, Ollama's KV cache holds the model's internal state for Claude Code's invariant system prompt prefix. Subsequent `claude -p` invocations against the same model **skip the prefill** — they just process the small user-message delta and generate the response.
+
+Verified empirically on tesseract 2026-06-16:
+- First call: 28m 2s (output: "PONG", 3 tokens)
+- Warm call (same prompt): 3.7s (output: "PING", 2 tokens)
+- Warm call (**different** prompt — "what is 2+2"): 5.7s (output: "4", 2 tokens)
+
+The third measurement is the critical one: prefix caching works across *independent* `claude -p` invocations as long as the system prompt is unchanged, and survives user-message variation. That's why pre-warming is just a single throwaway call per model.
+
+### Cache persistence
+
+The KV cache persists as long as:
+- `OLLAMA_KEEP_ALIVE=-1` is set (see `ollama-cpu.service` in `docs/`), so models don't get auto-evicted on idle
+- The Ollama process keeps running (a restart wipes the cache)
+- Nothing else evicts the model from memory (concurrent use of a larger model can knock the cached one out)
+
+If you start the matrix and OpenWebUI uses a different big model mid-run, you may pay a fresh warmup the next time the matrix calls into a model. Run the matrix when the box is otherwise quiet for predictable timing.
+
+### Implications for the harness
+
+- **`run-matrix.sh` pre-warms each model exactly once** before timing real tasks. The warmup itself is captured under `_warmup/<model>/` for reference, but its duration is not included in the per-task results.
+- **Tasks for a single model run serially** while it's hot. We don't interleave models because every interleave would pay a fresh warmup.
+- **No parallelism.** Concurrent runs would compete for the same model in cache and almost guarantee evictions.
+- **`run-task.sh` does not warm the model**, by design. It's meant to be orchestrated from `run-matrix.sh` (which warmed it) or called manually when you know the model is already hot.
+- **`AGENT_IMAGE` is `cc-forge-agent:latest`** — the same image forge sessions use. The harness exercises the actual production code path, not a stripped-down test harness.
+
+### Implications for the matrix design
+
+- Per-task timing is dominated by **output length**, not input length. Design task prompts that bound expected output to keep matrix runs tractable.
+- "Cold call" timing is interesting once, not per task. Capture it from `_warmup/` if you want it as a number.
+- The first model in a matrix run pays the full cold cost. Subsequent models pay only their model load (~1 min), not the full ~28 min, because Ollama's KV cache for *Claude Code's system prompt* is keyed per-model — but the same prompt-shape prefix may benefit from CPU-side memory-pressure caching even across models. Don't over-rely on this; assume each new model is ~25 min.
+
+### Implications for Track 3 (cloud Ollama services)
+
+The cache assumptions above are local-Ollama-specific. Cloud services like Together, Fireworks, or OpenRouter may not preserve KV caches across independent requests at all. The harness's pre-warm logic is harmless in that case (the warmup just adds one extra request), but per-task timing won't show the dramatic warm-vs-cold divide. Re-measure Track 1's assumptions when we get to Track 3.

--- a/scripts/eval/run-matrix.sh
+++ b/scripts/eval/run-matrix.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Run the full eval matrix: each model in $MODELS is pre-warmed once, then all
+# tasks in $TASKS_DIR are run against it serially while the model is hot.
+#
+# Usage:
+#   MODELS="qwen3-coder-32k gpt-oss:20b" \
+#   OLLAMA_URL=http://forge-ollama-proxy:11434 \
+#   run-matrix.sh
+#
+# Output: eval-results/$RUN_ID/<model>/<task>/{prompt.txt,output.json,stderr.log,meta.json}
+#         plus eval-results/$RUN_ID/_warmup/<model>/* for the warmup probe.
+#
+# Performance characteristics (see README.md for the full cost model):
+# - First call to a model: ~25-30 min on CPU (model load + Claude Code system
+#   prompt prefill). This is the warmup.
+# - Subsequent calls: dominated by output generation rate (~0.5 tok/s on CPU).
+
+set -euo pipefail
+
+MODELS="${MODELS:?MODELS env required, space-separated list of Ollama model names}"
+TASKS_DIR="${TASKS_DIR:-$(dirname "$0")/tasks}"
+OLLAMA_URL="${OLLAMA_URL:-http://forge-ollama-proxy:11434}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUTPUT_BASE="eval-results/$RUN_ID"
+AGENT_IMAGE="${AGENT_IMAGE:-cc-forge-agent:latest}"
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+[ -d "$TASKS_DIR" ] || { echo "TASKS_DIR not found: $TASKS_DIR" >&2; exit 1; }
+
+mkdir -p "$OUTPUT_BASE"
+echo "Eval run: $RUN_ID"
+echo "  models: $MODELS"
+echo "  tasks_dir: $TASKS_DIR"
+echo "  ollama_url: $OLLAMA_URL"
+echo "  output: $OUTPUT_BASE"
+
+# Build a small "task" with a trivial prompt purely to populate the model's
+# KV cache for Claude Code's system prompt. Reuses the same docker run path so
+# whatever Claude Code prefix gets cached is the same prefix the real tasks
+# will benefit from.
+warmup() {
+    local model="$1"
+    local warmup_out="$OUTPUT_BASE/_warmup/$model"
+    mkdir -p "$warmup_out"
+    echo "  warming $model (first call to a model is ~25-30 min on CPU)..."
+    local start end
+    start=$(date +%s)
+    local cmd
+    cmd=$(printf 'claude -p %q --no-session-persistence --output-format json --model %q --dangerously-skip-permissions' \
+        "OK" "$model")
+    docker run --rm \
+        --network forge-network \
+        -e ANTHROPIC_BASE_URL="$OLLAMA_URL" \
+        -e ANTHROPIC_AUTH_TOKEN=ollama \
+        --entrypoint /bin/bash \
+        "$AGENT_IMAGE" \
+        -c "$cmd" \
+        > "$warmup_out/output.json" 2> "$warmup_out/stderr.log" || true
+    end=$(date +%s)
+    echo "  warmup duration: $((end - start))s"
+}
+
+export OUTPUT_BASE OLLAMA_URL AGENT_IMAGE
+
+for model in $MODELS; do
+    echo
+    echo "=== Model: $model ==="
+    warmup "$model"
+
+    for task_dir in "$TASKS_DIR"/*/; do
+        [ -d "$task_dir" ] || continue
+        "$SCRIPT_DIR/run-task.sh" "$model" "$task_dir"
+    done
+done
+
+echo
+echo "Done. Results: $OUTPUT_BASE/"

--- a/scripts/eval/run-task.sh
+++ b/scripts/eval/run-task.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Run a single (model, task) through the Claude Code harness.
+#
+# Usage:
+#   OLLAMA_URL=http://forge-ollama-proxy:11434 \
+#   OUTPUT_BASE=eval-results/<run-id> \
+#   run-task.sh <model> <task-dir>
+#
+# Captures the agent's structured JSON output, stderr, and wall-clock duration
+# into $OUTPUT_BASE/<model>/<task>/. Does NOT pre-warm the model; orchestrate
+# pre-warming + iteration via run-matrix.sh.
+
+set -euo pipefail
+
+MODEL="${1:?model name required}"
+TASK_DIR="${2:?task dir required}"
+OLLAMA_URL="${OLLAMA_URL:-http://forge-ollama-proxy:11434}"
+OUTPUT_BASE="${OUTPUT_BASE:-eval-results/$(date -u +%Y%m%dT%H%M%SZ)}"
+AGENT_IMAGE="${AGENT_IMAGE:-cc-forge-agent:latest}"
+
+PROMPT_FILE="$TASK_DIR/prompt.txt"
+[ -f "$PROMPT_FILE" ] || { echo "no prompt.txt in $TASK_DIR" >&2; exit 1; }
+
+TASK_NAME=$(basename "$TASK_DIR")
+OUT="$OUTPUT_BASE/$MODEL/$TASK_NAME"
+mkdir -p "$OUT"
+cp "$PROMPT_FILE" "$OUT/prompt.txt"
+
+PROMPT=$(cat "$PROMPT_FILE")
+
+# Build the in-container claude command with shell-safe quoting.
+CLAUDE_CMD=$(printf 'claude -p %q --no-session-persistence --output-format json --model %q --dangerously-skip-permissions' \
+    "$PROMPT" "$MODEL")
+
+echo "[$(date +%H:%M:%S)] model=$MODEL task=$TASK_NAME"
+START=$(date +%s)
+
+docker run --rm \
+    --network forge-network \
+    -e ANTHROPIC_BASE_URL="$OLLAMA_URL" \
+    -e ANTHROPIC_AUTH_TOKEN=ollama \
+    --entrypoint /bin/bash \
+    "$AGENT_IMAGE" \
+    -c "$CLAUDE_CMD" \
+    > "$OUT/output.json" 2> "$OUT/stderr.log" || true
+
+END=$(date +%s)
+DURATION=$((END - START))
+
+# Capture a small meta file alongside the raw output.
+printf '{"model":%s,"task":%s,"duration_s":%d,"ollama_url":%s,"timestamp":%s}\n' \
+    "$(printf '%s' "$MODEL" | jq -R .)" \
+    "$(printf '%s' "$TASK_NAME" | jq -R .)" \
+    "$DURATION" \
+    "$(printf '%s' "$OLLAMA_URL" | jq -R .)" \
+    "$(date -u +'%Y-%m-%dT%H:%M:%SZ' | jq -R .)" \
+    > "$OUT/meta.json"
+
+echo "[$(date +%H:%M:%S)]   ${DURATION}s → $OUT/"

--- a/scripts/eval/run-task.sh
+++ b/scripts/eval/run-task.sh
@@ -35,6 +35,8 @@ CLAUDE_CMD=$(printf 'claude -p %q --no-session-persistence --output-format json 
 echo "[$(date +%H:%M:%S)] model=$MODEL task=$TASK_NAME"
 START=$(date +%s)
 
+# Capture exit code so meta.json reflects actual success/failure — failed runs
+# should not look like valid task outputs to downstream analysis.
 docker run --rm \
     --network forge-network \
     -e ANTHROPIC_BASE_URL="$OLLAMA_URL" \
@@ -42,18 +44,23 @@ docker run --rm \
     --entrypoint /bin/bash \
     "$AGENT_IMAGE" \
     -c "$CLAUDE_CMD" \
-    > "$OUT/output.json" 2> "$OUT/stderr.log" || true
+    > "$OUT/output.json" 2> "$OUT/stderr.log" && EXIT_CODE=0 || EXIT_CODE=$?
 
 END=$(date +%s)
 DURATION=$((END - START))
 
 # Capture a small meta file alongside the raw output.
-printf '{"model":%s,"task":%s,"duration_s":%d,"ollama_url":%s,"timestamp":%s}\n' \
+printf '{"model":%s,"task":%s,"duration_s":%d,"exit_code":%d,"ollama_url":%s,"timestamp":%s}\n' \
     "$(printf '%s' "$MODEL" | jq -R .)" \
     "$(printf '%s' "$TASK_NAME" | jq -R .)" \
     "$DURATION" \
+    "$EXIT_CODE" \
     "$(printf '%s' "$OLLAMA_URL" | jq -R .)" \
     "$(date -u +'%Y-%m-%dT%H:%M:%SZ' | jq -R .)" \
     > "$OUT/meta.json"
 
-echo "[$(date +%H:%M:%S)]   ${DURATION}s → $OUT/"
+if [ "$EXIT_CODE" -eq 0 ]; then
+    echo "[$(date +%H:%M:%S)]   ${DURATION}s → $OUT/"
+else
+    echo "[$(date +%H:%M:%S)]   FAILED exit=$EXIT_CODE after ${DURATION}s → $OUT/" >&2
+fi

--- a/scripts/eval/tasks/01-sanity-pong/expect.md
+++ b/scripts/eval/tasks/01-sanity-pong/expect.md
@@ -1,0 +1,22 @@
+# 01-sanity-pong
+
+## Purpose
+
+Smoke test the harness end-to-end with a prompt expecting trivial output (~3 tokens). Verifies that:
+
+- The agent image starts cleanly
+- `claude -p` produces structured JSON
+- The model follows a simple instruction
+- Total elapsed time is reasonable when warm
+
+## Pass criteria
+
+The captured `output.json` shows:
+
+- `is_error: false`
+- `result` is the string `"PONG"` (case-insensitive match acceptable; trailing whitespace acceptable)
+- `usage.output_tokens` ≤ 10
+
+## Notes
+
+This is intentionally not a meaningful capability test. Use it to confirm the harness works before adding real tasks. A model that fails this task is broken or misconfigured, not weak.

--- a/scripts/eval/tasks/01-sanity-pong/prompt.txt
+++ b/scripts/eval/tasks/01-sanity-pong/prompt.txt
@@ -1,0 +1,1 @@
+Reply with the single word PONG and nothing else.


### PR DESCRIPTION
## Summary

Adds the Track 1 evaluation scaffolding: scripts that run the Claude-Code-with-local-Ollama matrix, plus a documented understanding of the surprising performance characteristics we discovered while probing it.

This PR ships **the harness and the cost model**, not the actual matrix results. Running the matrix happens in a follow-up — the harness produces the data, the eval doc is updated with conclusions.

## What's in here

- `scripts/eval/run-task.sh` — runs a single (model, task) and captures structured output to `eval-results/<run-id>/<model>/<task>/`
- `scripts/eval/run-matrix.sh` — pre-warms each listed model once, then runs all tasks against it serially while it's hot; orchestrates across models
- `scripts/eval/README.md` — usage docs **plus the canonical cost model**: why first-call is ~28 min, why subsequent calls are seconds, what cache properties survive, what they imply for harness design
- `scripts/eval/tasks/01-sanity-pong/` — minimal smoke task that validates the harness end-to-end without burning a long generation
- `docs/CLAUDE-CODE-LOCAL-MODELS.md` — slim public-facing surface for the cost model and eventual results, pointing at the harness README for depth
- `.gitignore` — `eval-results/`

## The cost model in one paragraph

Running `claude -p` against a local Ollama model on CPU has a sharp two-mode profile: **first call ~25-30 min** (most of it prefilling Claude Code's large invariant system prompt through the model on CPU at ~5 tok/sec), **every subsequent call seconds for short responses** (Ollama's KV cache reuses the system-prompt prefix even across independent `claude -p` invocations and survives user-message variation). The harness's design — pre-warm once per model, then run tasks serially while hot — falls directly out of this. Verified empirically on tesseract 2026-06-16; full decomposition with measurements in `scripts/eval/README.md`.

## How to run an eval matrix

```
ssh tesseract
cd ~/Code/cc_forge.wt/feature/eval-harness/   # or wherever the branch lives
MODELS="qwen3-coder-32k gpt-oss:20b" \
OLLAMA_URL="http://forge-ollama-proxy:11434" \
./scripts/eval/run-matrix.sh
```

Output in `eval-results/<run-id>/`. Plan ~25-30 min cold per model + ~7 min warm per task.

## Test plan

- [x] Both scripts pass `bash -n`
- [x] Sample task directory is well-formed (prompt.txt + expect.md)
- [ ] First end-to-end run on tesseract (deliberately deferred to a follow-up — this PR is scaffolding)

## Related issues

- #57 — `forge doctor` pre-flight check should validate the same things this harness assumes (Ollama reachable, model present, etc.)
- #53 — community research pass, sequenced after a first matrix run
- #54 — cloud Ollama services, separate eval matrix sharing this harness shape