### PR TITLE
Split forge promote across the host boundary (server reads Forgejo, workstation writes GitHub)

### DIFF
--- a/scripts/remote-forge/workstation-wrapper
+++ b/scripts/remote-forge/workstation-wrapper
@@ -75,6 +75,12 @@ elif [ "$SUBCMD" = "promote" ]; then
     FORGE_FORGEJO_USER="${FORGE_FORGEJO_USER:-cc_forge_admin}"
     FORGE_FORGEJO_PORT="${FORGE_FORGEJO_PORT:-3000}"
 
+    # promote does its GitHub write locally; both tools are required on the workstation.
+    command -v python3 >/dev/null || {
+        echo "forge: python3 is required for 'forge promote' on the workstation" >&2; exit 1; }
+    command -v gh >/dev/null || {
+        echo "forge: gh CLI is required for 'forge promote' (https://cli.github.com)" >&2; exit 1; }
+
     PR_NUM="$1"
     [ -n "$PR_NUM" ] || { echo "forge: usage: forge promote <pr-number>" >&2; exit 1; }
 
@@ -85,10 +91,22 @@ elif [ "$SUBCMD" = "promote" ]; then
     # 1. Read PR metadata from the server (reads its local Forgejo).
     META=$(ssh "$FORGE_SERVER" "forge pr-show $(printf %q "$PR_NUM") --repo-name $(printf %q "$REPO")") || {
         echo "forge: could not read PR $PR_NUM from $FORGE_SERVER" >&2; exit 1; }
-    HEAD=$(printf '%s' "$META" | python3 -c "import sys,json;print(json.load(sys.stdin)['head'])")
-    BASE=$(printf '%s' "$META" | python3 -c "import sys,json;print(json.load(sys.stdin)['base'])")
-    TITLE=$(printf '%s' "$META" | python3 -c "import sys,json;print(json.load(sys.stdin)['title'])")
-    BODY=$(printf '%s' "$META" | python3 -c "import sys,json;print(json.load(sys.stdin)['body'])")
+    # Parse once: NUL-delimited fields survive multi-line titles/bodies, and a bad
+    # payload (invalid JSON or missing keys) becomes a clean error, not a traceback.
+    # The inner python3's exit status isn't visible through process substitution, so
+    # validate by field count: a bad payload yields fewer than 4 NUL-delimited fields.
+    mapfile -d '' -t FIELDS < <(printf '%s' "$META" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    for k in ("head", "base", "title", "body"):
+        sys.stdout.write(d[k]); sys.stdout.write("\0")
+except Exception:
+    sys.exit(1)
+')
+    [ "${#FIELDS[@]}" -eq 4 ] || {
+        echo "forge: invalid PR metadata from server: $META" >&2; exit 1; }
+    HEAD="${FIELDS[0]}"; BASE="${FIELDS[1]}"; TITLE="${FIELDS[2]}"; BODY="${FIELDS[3]}"
 
     # 2. Can't reset a checked-out branch.
     if [ "$(git rev-parse --abbrev-ref HEAD)" = "$HEAD" ]; then

--- a/scripts/remote-forge/workstation-wrapper
+++ b/scripts/remote-forge/workstation-wrapper
@@ -68,6 +68,47 @@ if [ "$SUBCMD" = "run" ]; then
     else
         echo "forge: could not fetch from Forgejo (is $FORGE_SERVER:$FORGE_FORGEJO_PORT reachable?)" >&2
     fi
+elif [ "$SUBCMD" = "promote" ]; then
+    # Split across the host boundary: the server reads its local Forgejo (it has the
+    # token); the workstation does the GitHub write with its own ambient gh auth.
+    FORGE_SERVER="${FORGE_SERVER:-tesseract}"
+    FORGE_FORGEJO_USER="${FORGE_FORGEJO_USER:-cc_forge_admin}"
+    FORGE_FORGEJO_PORT="${FORGE_FORGEJO_PORT:-3000}"
+
+    PR_NUM="$1"
+    [ -n "$PR_NUM" ] || { echo "forge: usage: forge promote <pr-number>" >&2; exit 1; }
+
+    REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null) || {
+        echo "forge: not a git repository" >&2; exit 1; }
+    REPO=$(basename "$REPO_PATH")
+
+    # 1. Read PR metadata from the server (reads its local Forgejo).
+    META=$(ssh "$FORGE_SERVER" "forge pr-show $(printf %q "$PR_NUM") --repo-name $(printf %q "$REPO")") || {
+        echo "forge: could not read PR $PR_NUM from $FORGE_SERVER" >&2; exit 1; }
+    HEAD=$(printf '%s' "$META" | python3 -c "import sys,json;print(json.load(sys.stdin)['head'])")
+    BASE=$(printf '%s' "$META" | python3 -c "import sys,json;print(json.load(sys.stdin)['base'])")
+    TITLE=$(printf '%s' "$META" | python3 -c "import sys,json;print(json.load(sys.stdin)['title'])")
+    BODY=$(printf '%s' "$META" | python3 -c "import sys,json;print(json.load(sys.stdin)['body'])")
+
+    # 2. Can't reset a checked-out branch.
+    if [ "$(git rev-parse --abbrev-ref HEAD)" = "$HEAD" ]; then
+        echo "forge: branch '$HEAD' is checked out; switch away before promoting" >&2; exit 1
+    fi
+
+    # 3. Ensure the forgejo remote, fetch the agent's branch (read-only).
+    FORGEJO_URL="http://${FORGE_SERVER}:${FORGE_FORGEJO_PORT}/${FORGE_FORGEJO_USER}/${REPO}.git"
+    if ! CURRENT_URL=$(git remote get-url forgejo 2>/dev/null); then
+        git remote add forgejo "$FORGEJO_URL"
+    elif [ "$CURRENT_URL" != "$FORGEJO_URL" ]; then
+        git remote set-url forgejo "$FORGEJO_URL"
+    fi
+    git fetch forgejo >&2
+
+    # 4. Materialize the branch and open the GitHub PR with the workstation's gh
+    #    (no -R: gh infers the repo from origin, so no FORGE_GITHUB_* config is needed here).
+    git branch -f "$HEAD" "forgejo/$HEAD"
+    git push origin "$HEAD" >&2
+    gh pr create --head "$HEAD" --base "$BASE" --title "$TITLE" --body "$BODY"
 else
     FORGE_SERVER="${FORGE_SERVER:-tesseract}"
     exec ssh -t "$FORGE_SERVER" "forge $(printf %q "$SUBCMD") $(printf '%q ' "$@")"

--- a/src/cc_forge/cli.py
+++ b/src/cc_forge/cli.py
@@ -53,6 +53,28 @@ def promote(pr: int, repo: str, remote: str) -> None:
     click.echo(url)
 
 
+@main.command(name="pr-show")
+@click.argument("pr", type=int)
+@click.option("--repo-name", default=None,
+              help="Forgejo repo name (default: derive from the current repo's origin).")
+@click.option("--repo", default=".", help="Path to git repository (for deriving --repo-name).")
+def pr_show(pr: int, repo_name: str | None, repo: str) -> None:
+    """Print a Forgejo PR's metadata as JSON (head, base, title, body)."""
+    import json
+
+    from cc_forge.config import load_config
+    from cc_forge.git import get_repo_name, get_repo_root, is_git_repo
+    from cc_forge.promote import pr_metadata
+
+    if not repo_name:
+        if not is_git_repo(repo):
+            raise click.ClickException("Run inside a git repo or pass --repo-name.")
+        repo_name = get_repo_name(get_repo_root(repo))
+
+    cfg = load_config()
+    click.echo(json.dumps(pr_metadata(cfg, pr, repo_name)))
+
+
 @main.command()
 def status() -> None:
     """Show running forge sessions."""

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -74,7 +74,7 @@ def pr_metadata(config: ForgeConfig, pr_number: int, repo_name: str) -> dict:
         with ForgejoClient(config) as forgejo:
             owner = forgejo.get_current_user()
             pr = forgejo.get_pull_request(owner, repo_name, pr_number)
-    except (httpx.ConnectError, httpx.TimeoutException) as e:
+    except httpx.RequestError as e:
         raise click.ClickException(f"Forgejo unreachable at {config.forgejo_url}: {e}")
     except ForgejoError as e:
         raise click.ClickException(f"Forgejo: {e}")
@@ -83,6 +83,7 @@ def pr_metadata(config: ForgeConfig, pr_number: int, repo_name: str) -> dict:
         "base": pr["base"]["ref"],
         "title": pr["title"],
         "body": pr.get("body") or "",
+        "url": pr.get("html_url", ""),
     }
 
 

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -7,9 +7,10 @@ import subprocess
 from pathlib import Path
 
 import click
+import httpx
 
 from cc_forge.config import ForgeConfig
-from cc_forge.forgejo import ForgejoClient
+from cc_forge.forgejo import ForgejoClient, ForgejoError
 from cc_forge.git import (
     create_branch_from_ref,
     fetch_remote,
@@ -40,14 +41,8 @@ def promote_pull_request(
     repo_name = get_repo_name(repo_root)
     github_repo = config.resolve_github_repo(repo_name)
 
-    with ForgejoClient(config) as forgejo:
-        owner = forgejo.get_current_user()
-        pr = forgejo.get_pull_request(owner, repo_name, pr_number)
-
-    head = pr["head"]["ref"]
-    base = pr["base"]["ref"]
-    title = pr["title"]
-    body = pr.get("body") or ""
+    meta = pr_metadata(config, pr_number, repo_name)
+    head, base, title, body = meta["head"], meta["base"], meta["title"], meta["body"]
 
     if not has_remote(repo_root, "forgejo"):
         raise click.ClickException(
@@ -68,6 +63,27 @@ def promote_pull_request(
     push_to_remote(repo_root, remote, head, set_upstream=False)
 
     return _gh_pr_create(config, repo_root, github_repo, head, base, title, body)
+
+
+def pr_metadata(config: ForgeConfig, pr_number: int, repo_name: str) -> dict:
+    """Read a Forgejo PR's metadata: {head, base, title, body}.
+
+    Raises a ClickException on an unreachable Forgejo or an API error.
+    """
+    try:
+        with ForgejoClient(config) as forgejo:
+            owner = forgejo.get_current_user()
+            pr = forgejo.get_pull_request(owner, repo_name, pr_number)
+    except (httpx.ConnectError, httpx.TimeoutException) as e:
+        raise click.ClickException(f"Forgejo unreachable at {config.forgejo_url}: {e}")
+    except ForgejoError as e:
+        raise click.ClickException(f"Forgejo: {e}")
+    return {
+        "head": pr["head"]["ref"],
+        "base": pr["base"]["ref"],
+        "title": pr["title"],
+        "body": pr.get("body") or "",
+    }
 
 
 def _remote_owner_repo(url: str) -> str | None:

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -136,6 +136,29 @@ def test_promote_errors_when_gh_missing(monkeypatch):
         promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
 
 
+def test_pr_metadata_happy(monkeypatch):
+    monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: _fake_forgejo(PR))
+    meta = promote_mod.pr_metadata(_config(), 7, "cc_forge")
+    assert meta == {
+        "head": "agent/feature", "base": "main", "title": "Add feature", "body": "Body.",
+    }
+
+
+def test_pr_metadata_unreachable(monkeypatch):
+    import httpx
+
+    def boom(c):
+        m = MagicMock()
+        m.__enter__.return_value = m
+        m.__exit__.return_value = False
+        m.get_current_user.side_effect = httpx.ConnectError("refused")
+        return m
+
+    monkeypatch.setattr(promote_mod, "ForgejoClient", boom)
+    with pytest.raises(click.ClickException, match="unreachable"):
+        promote_mod.pr_metadata(_config(), 7, "cc_forge")
+
+
 @pytest.mark.parametrize("url,expected", [
     ("https://github.com/me/cc_forge.git", "me/cc_forge"),
     ("https://github.com/me/cc_forge", "me/cc_forge"),

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -16,6 +16,7 @@ PR = {
     "body": "Body.",
     "head": {"ref": "agent/feature"},
     "base": {"ref": "main"},
+    "html_url": "http://localhost:3000/cc_forge_admin/cc_forge/pulls/7",
 }
 
 
@@ -141,17 +142,19 @@ def test_pr_metadata_happy(monkeypatch):
     meta = promote_mod.pr_metadata(_config(), 7, "cc_forge")
     assert meta == {
         "head": "agent/feature", "base": "main", "title": "Add feature", "body": "Body.",
+        "url": "http://localhost:3000/cc_forge_admin/cc_forge/pulls/7",
     }
 
 
-def test_pr_metadata_unreachable(monkeypatch):
+@pytest.mark.parametrize("err", ["ConnectError", "ReadError", "ProtocolError"])
+def test_pr_metadata_unreachable(monkeypatch, err):
     import httpx
 
     def boom(c):
         m = MagicMock()
         m.__enter__.return_value = m
         m.__exit__.return_value = False
-        m.get_current_user.side_effect = httpx.ConnectError("refused")
+        m.get_current_user.side_effect = getattr(httpx, err)("boom")
         return m
 
     monkeypatch.setattr(promote_mod, "ForgejoClient", boom)

--- a/tests/unit/test_workstation_wrapper.py
+++ b/tests/unit/test_workstation_wrapper.py
@@ -21,6 +21,7 @@ _SSH_SHIM = """#!/bin/bash
 echo "ssh $*" >> "$CALL_LOG"
 case "$*" in
     *"forge run"*) exit "${SSH_RUN_RC:-0}";;
+    *"forge pr-show"*) printf '%s' "${PR_META_JSON:-}"; exit "${SSH_PRSHOW_RC:-0}";;
     *) exit "${SSH_RC:-0}";;
 esac
 """
@@ -34,6 +35,7 @@ _GIT_SHIM = """#!/bin/bash
 echo "git $*" >> "$CALL_LOG"
 case "$1 $2" in
     "rev-parse --show-toplevel") echo "${FAKE_REPO_PATH:-/home/u/myrepo}"; exit 0;;
+    "rev-parse --abbrev-ref") echo "${FAKE_CURRENT_BRANCH:-main}"; exit 0;;
     "remote get-url")
         if [ -n "$GIT_HAS_REMOTE" ]; then echo "$GIT_REMOTE_URL"; exit 0; fi
         exit 2;;
@@ -43,13 +45,21 @@ case "$1 $2" in
 esac
 """
 
+_GH_SHIM = """#!/bin/bash
+echo "gh $*" >> "$CALL_LOG"
+echo "https://github.com/me/myrepo/pull/9"
+exit "${GH_RC:-0}"
+"""
+
 
 @pytest.fixture()
 def shim_bin(tmp_path: Path) -> Path:
-    """Create a bin/ dir of ssh/rsync/git shims and return it."""
+    """Create a bin/ dir of ssh/rsync/git/gh shims and return it."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    for name, body in (("ssh", _SSH_SHIM), ("rsync", _RSYNC_SHIM), ("git", _GIT_SHIM)):
+    for name, body in (
+        ("ssh", _SSH_SHIM), ("rsync", _RSYNC_SHIM), ("git", _GIT_SHIM), ("gh", _GH_SHIM)
+    ):
         shim = bin_dir / name
         shim.write_text(body)
         shim.chmod(0o755)
@@ -152,3 +162,53 @@ def test_passthrough_subcommand_skips_rsync(shim_bin, tmp_path):
     assert proc.returncode == 0
     assert "rsync" not in log
     assert "forge status" in log
+
+
+_META = '{"head":"agent/feature","base":"main","title":"Add it","body":"Body."}'
+
+
+def test_promote_reads_metadata_then_writes_github(shim_bin, tmp_path):
+    proc, log = run_wrapper(
+        shim_bin, tmp_path, ["promote", "4"],
+        PR_META_JSON=_META,
+        GIT_HAS_REMOTE="1",
+        GIT_REMOTE_URL="http://tesseract:3000/cc_forge_admin/myrepo.git",
+    )
+    assert proc.returncode == 0, proc.stderr
+    # metadata read happens on the server, not locally
+    assert "forge pr-show 4 --repo-name myrepo" in log
+    # branch materialized + pushed to origin (GitHub) locally
+    assert "git branch -f agent/feature forgejo/agent/feature" in log
+    assert "git push origin agent/feature" in log
+    # GitHub PR opened with the carried metadata, no -R (inferred from origin)
+    assert "gh pr create --head agent/feature --base main --title Add it --body Body." in log
+    assert "-R" not in log
+    # the gh PR URL is surfaced on stdout
+    assert "https://github.com/me/myrepo/pull/9" in proc.stdout
+
+
+def test_promote_blocks_when_head_checked_out(shim_bin, tmp_path):
+    proc, log = run_wrapper(
+        shim_bin, tmp_path, ["promote", "4"],
+        PR_META_JSON=_META,
+        FAKE_CURRENT_BRANCH="agent/feature",
+    )
+    assert proc.returncode == 1
+    assert "checked out" in proc.stderr
+    assert "gh pr create" not in log  # never reached the GitHub write
+
+
+def test_promote_requires_pr_number(shim_bin, tmp_path):
+    proc, log = run_wrapper(shim_bin, tmp_path, ["promote"])
+    assert proc.returncode == 1
+    assert "usage" in proc.stderr
+    assert "ssh" not in log
+
+
+def test_promote_fails_when_pr_show_fails(shim_bin, tmp_path):
+    proc, log = run_wrapper(
+        shim_bin, tmp_path, ["promote", "4"], PR_META_JSON=_META, SSH_PRSHOW_RC="1",
+    )
+    assert proc.returncode == 1
+    assert "could not read PR 4" in proc.stderr
+    assert "gh pr create" not in log

--- a/tests/unit/test_workstation_wrapper.py
+++ b/tests/unit/test_workstation_wrapper.py
@@ -212,3 +212,10 @@ def test_promote_fails_when_pr_show_fails(shim_bin, tmp_path):
     assert proc.returncode == 1
     assert "could not read PR 4" in proc.stderr
     assert "gh pr create" not in log
+
+
+def test_promote_rejects_invalid_metadata(shim_bin, tmp_path):
+    proc, log = run_wrapper(shim_bin, tmp_path, ["promote", "4"], PR_META_JSON="not json")
+    assert proc.returncode == 1
+    assert "invalid PR metadata" in proc.stderr
+    assert "gh pr create" not in log


### PR DESCRIPTION
## Summary

Implements #60 (Option B): `forge promote` now splits across the host boundary so the **workstation** does the GitHub write with its **own ambient `gh` auth**, while the **server** does the Forgejo read (where the token + local Forgejo live). Validated by the server-side smoke test in #60 — the only step that was awkward server-side (`gh pr create`) now runs where `gh` and the human's auth actually are.

## What changed

**Python (server-side read):**
- `forge pr-show <n> [--repo-name <name>]` — new read-only command that prints `{head, base, title, body}` JSON from the local Forgejo. Runs from anywhere (takes `--repo-name`, so it doesn't need to be inside a repo).
- `promote.py` refactored: the Forgejo read is extracted into `pr_metadata()` (reused by both `pr-show` and the monolithic `promote`), with a clean "Forgejo unreachable" error instead of a bare connection traceback (the gap surfaced by the #60 smoke test).
- The monolithic `forge promote` is unchanged in behavior — still valid for same-host use (and future #42).

**Wrapper (workstation-side write):**
- `promote` becomes a third special-cased subcommand (alongside `run`): `ssh server forge pr-show` for metadata → ensure `forgejo` remote + fetch → materialize the branch → `git push origin` → `gh pr create`.
- No `-R` on `gh pr create`: the GitHub repo is inferred from the workstation repo's `origin`, so **no `FORGE_GITHUB_*` config is needed on the workstation**.
- Guards mirror the Python path: rejects a missing PR number, a non-repo, and a checked-out head branch.

## Why this shape

Per #60: the workstation already has the branch (the post-`run` fetch), so the only cross-host need is read-only PR metadata — handed back over the SSH trust we already rely on. The Forgejo token stays confined to the server. The wrapper is interim scaffolding (issue #42), so the GitHub write lives in ~15 lines of bash rather than installing Python forge on the workstation; it retires with the wrapper when #42 lands.

## Test plan

- [x] 138 unit tests pass — includes `pr-show`/`pr_metadata` (happy + unreachable) and four wrapper `promote` cases (metadata read → GitHub write, checked-out-head guard, missing PR number, `pr-show` failure), driven by the existing ssh/git/gh shim harness.
- [ ] Live end-to-end from a real workstation against tesseract (the thing this PR exists to enable).

Closes #60.
