### PR TITLE
Add per-task workspace support and first real task (02-fix-typo)

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -33,19 +33,36 @@ eval-results/<run-id>/
         ├── prompt.txt      # Copy of the task's prompt for context
         ├── output.json     # Full claude -p response (parse with jq)
         ├── stderr.log      # Anything claude or docker wrote to stderr
-        └── meta.json       # {model, task, duration_s, ollama_url, timestamp}
+        ├── setup.log       # setup.sh output (only if task has setup.sh)
+        ├── score.log       # score.sh output (only if task has score.sh)
+        ├── score-exit      # score.sh exit code (only if task has score.sh)
+        ├── workspace/      # Final state of /workspace after the run
+        └── meta.json       # {model, task, duration_s, exit_code, score?, ollama_url, timestamp}
 ```
 
 ## Tasks
 
-A task is just a directory under `scripts/eval/tasks/<NN-name>/` containing:
+A task is a directory under `scripts/eval/tasks/<NN-name>/`. Files (all optional except `prompt.txt`):
 
-- `prompt.txt` — the user message sent to `claude -p`
-- `expect.md` — human-readable success criteria for grading the run
+| File | Required | What it does |
+|------|----------|--------------|
+| `prompt.txt` | yes | The user message sent to `claude -p`. |
+| `setup.sh` | no | Runs in the container before `claude -p`, with `cwd=/workspace`. Populates the workspace (write files, `git init`, etc.). Failure aborts the run with exit 90. |
+| `score.sh` | no | Runs in the container after `claude -p`, with `cwd=/workspace`. Exit 0 = pass, non-zero = fail. Result is captured in `meta.json` as `"score"`. |
+| `expect.md` | no | Human-readable success criteria. For tasks without `score.sh`, this is the grading reference. |
 
 Tasks are run in lexical order. Prefix names with `01-`, `02-`, etc. to control ordering.
 
-`01-sanity-pong/` is provided as the minimal smoke task — it validates the harness works end-to-end and produces ~3 tokens of output, so it finishes fast even with a fully cold model. Add real tasks as separate directories.
+### Inside the container, a task sees three mount points
+
+- `/workspace` — fresh per run. Setup writes here, the agent works here, score reads here. Captured at `eval-results/.../<task>/workspace/` after the run.
+- `/task` — read-only mount of the task source directory. `setup.sh`, `score.sh`, and any fixtures the task ships with are reachable here.
+- `/meta` — read-write mount of the result directory. The harness writes `output.json`, `stderr.log`, `setup.log`, etc. here; you don't normally touch it from inside the container.
+
+### Existing tasks
+
+- `01-sanity-pong/` — minimal smoke. No `setup.sh`, no `score.sh`. Validates the harness end-to-end with a trivial prompt that produces ~3 tokens. Finishes fast even on a fully cold model. Use this when iterating on the harness itself, not when evaluating models.
+- `02-fix-typo/` — first real capability task. Workspace contains a `README.md` with a typo; agent must find and fix it; `score.sh` verifies the file now contains `Hello World`. Small enough to keep wall-clock cost bounded.
 
 ---
 

--- a/scripts/eval/run-task.sh
+++ b/scripts/eval/run-task.sh
@@ -6,9 +6,27 @@
 #   OUTPUT_BASE=eval-results/<run-id> \
 #   run-task.sh <model> <task-dir>
 #
-# Captures the agent's structured JSON output, stderr, and wall-clock duration
-# into $OUTPUT_BASE/<model>/<task>/. Does NOT pre-warm the model; orchestrate
-# pre-warming + iteration via run-matrix.sh.
+# Per-task layout (each file optional except prompt.txt):
+#   <task-dir>/prompt.txt   - required: user prompt sent to claude -p
+#   <task-dir>/setup.sh     - optional: runs in container before claude (cwd=/workspace)
+#   <task-dir>/score.sh     - optional: runs in container after claude (cwd=/workspace)
+#                              exit 0 = pass, non-zero = fail (recorded in meta.json)
+#   <task-dir>/expect.md    - optional: human-readable success criteria
+#
+# Inside the container:
+#   /workspace  - fresh per run; setup.sh populates, claude modifies, score.sh checks
+#   /task       - read-only mount of the task source dir
+#   /meta       - read-write mount of $OUT (where output.json, meta.json land)
+#
+# Outputs in $OUT = $OUTPUT_BASE/<model>/<task>/:
+#   prompt.txt          copy of the task's prompt
+#   output.json         claude -p's full structured response
+#   stderr.log          anything claude wrote to stderr
+#   setup.log           setup.sh output (only if setup.sh ran)
+#   score.log           score.sh output (only if score.sh ran)
+#   score-exit          score.sh exit code (only if score.sh ran)
+#   meta.json           {model, task, duration_s, exit_code, score?, ollama_url, timestamp}
+#   workspace/          final state of /workspace after claude exited
 
 set -euo pipefail
 
@@ -22,9 +40,13 @@ PROMPT_FILE="$TASK_DIR/prompt.txt"
 [ -f "$PROMPT_FILE" ] || { echo "no prompt.txt in $TASK_DIR" >&2; exit 1; }
 
 TASK_NAME=$(basename "$TASK_DIR")
+TASK_DIR_ABS=$(cd "$TASK_DIR" && pwd)
+
 OUT="$OUTPUT_BASE/$MODEL/$TASK_NAME"
-mkdir -p "$OUT"
+mkdir -p "$OUT/workspace"
 cp "$PROMPT_FILE" "$OUT/prompt.txt"
+OUT_ABS=$(cd "$OUT" && pwd)
+WS_ABS=$(cd "$OUT/workspace" && pwd)
 
 PROMPT=$(cat "$PROMPT_FILE")
 
@@ -32,35 +54,72 @@ PROMPT=$(cat "$PROMPT_FILE")
 CLAUDE_CMD=$(printf 'claude -p %q --no-session-persistence --output-format json --model %q --dangerously-skip-permissions' \
     "$PROMPT" "$MODEL")
 
+# Inline script run inside the container. $CLAUDE_CMD is expanded by the outer
+# shell; \$ sequences are escaped so they resolve inside the container.
+# `set -u` (no `-e`) lets us continue past a failed claude so score.sh still runs.
+INNER=$(cat <<EOF
+set -uo pipefail
+cd /workspace
+if [ -f /task/setup.sh ]; then
+    bash /task/setup.sh > /meta/setup.log 2>&1 || {
+        echo "setup.sh failed (exit \$?)" >&2
+        exit 90
+    }
+fi
+$CLAUDE_CMD > /meta/output.json 2> /meta/stderr.log
+CLAUDE_EXIT=\$?
+if [ -f /task/score.sh ]; then
+    (cd /workspace && bash /task/score.sh) > /meta/score.log 2>&1
+    echo \$? > /meta/score-exit
+fi
+exit \$CLAUDE_EXIT
+EOF
+)
+
 echo "[$(date +%H:%M:%S)] model=$MODEL task=$TASK_NAME"
 START=$(date +%s)
 
-# Capture exit code so meta.json reflects actual success/failure — failed runs
-# should not look like valid task outputs to downstream analysis.
 docker run --rm \
     --network forge-network \
+    -v "$TASK_DIR_ABS:/task:ro" \
+    -v "$WS_ABS:/workspace" \
+    -v "$OUT_ABS:/meta" \
     -e ANTHROPIC_BASE_URL="$OLLAMA_URL" \
     -e ANTHROPIC_AUTH_TOKEN=ollama \
     --entrypoint /bin/bash \
     "$AGENT_IMAGE" \
-    -c "$CLAUDE_CMD" \
-    > "$OUT/output.json" 2> "$OUT/stderr.log" && EXIT_CODE=0 || EXIT_CODE=$?
+    -c "$INNER" \
+    && EXIT_CODE=0 || EXIT_CODE=$?
 
 END=$(date +%s)
 DURATION=$((END - START))
 
-# Capture a small meta file alongside the raw output.
-printf '{"model":%s,"task":%s,"duration_s":%d,"exit_code":%d,"ollama_url":%s,"timestamp":%s}\n' \
+# Score result (if score.sh ran)
+SCORE_FIELD=""
+SCORE_DISPLAY=""
+if [ -f "$OUT/score-exit" ]; then
+    SCORE_EXIT=$(cat "$OUT/score-exit")
+    if [ "$SCORE_EXIT" -eq 0 ]; then
+        SCORE_FIELD=',"score":"pass","score_exit":0'
+        SCORE_DISPLAY=" [score: pass]"
+    else
+        SCORE_FIELD=",\"score\":\"fail\",\"score_exit\":$SCORE_EXIT"
+        SCORE_DISPLAY=" [score: fail($SCORE_EXIT)]"
+    fi
+fi
+
+printf '{"model":%s,"task":%s,"duration_s":%d,"exit_code":%d%s,"ollama_url":%s,"timestamp":%s}\n' \
     "$(printf '%s' "$MODEL" | jq -R .)" \
     "$(printf '%s' "$TASK_NAME" | jq -R .)" \
     "$DURATION" \
     "$EXIT_CODE" \
+    "$SCORE_FIELD" \
     "$(printf '%s' "$OLLAMA_URL" | jq -R .)" \
     "$(date -u +'%Y-%m-%dT%H:%M:%SZ' | jq -R .)" \
     > "$OUT/meta.json"
 
 if [ "$EXIT_CODE" -eq 0 ]; then
-    echo "[$(date +%H:%M:%S)]   ${DURATION}s → $OUT/"
+    echo "[$(date +%H:%M:%S)]   ${DURATION}s${SCORE_DISPLAY} → $OUT/"
 else
-    echo "[$(date +%H:%M:%S)]   FAILED exit=$EXIT_CODE after ${DURATION}s → $OUT/" >&2
+    echo "[$(date +%H:%M:%S)]   FAILED exit=$EXIT_CODE after ${DURATION}s${SCORE_DISPLAY} → $OUT/" >&2
 fi

--- a/scripts/eval/run-task.sh
+++ b/scripts/eval/run-task.sh
@@ -43,6 +43,10 @@ TASK_NAME=$(basename "$TASK_DIR")
 TASK_DIR_ABS=$(cd "$TASK_DIR" && pwd)
 
 OUT="$OUTPUT_BASE/$MODEL/$TASK_NAME"
+# Clear any stale artifacts from a previous run into the same OUTPUT_BASE so
+# /workspace is genuinely fresh and conditional outputs (setup.log, score.log,
+# score-exit) from a prior run don't leak into this run's meta.json.
+rm -rf "$OUT"
 mkdir -p "$OUT/workspace"
 cp "$PROMPT_FILE" "$OUT/prompt.txt"
 OUT_ABS=$(cd "$OUT" && pwd)
@@ -61,10 +65,12 @@ INNER=$(cat <<EOF
 set -uo pipefail
 cd /workspace
 if [ -f /task/setup.sh ]; then
-    bash /task/setup.sh > /meta/setup.log 2>&1 || {
-        echo "setup.sh failed (exit \$?)" >&2
+    bash /task/setup.sh > /meta/setup.log 2>&1
+    SETUP_EXIT=\$?
+    if [ "\$SETUP_EXIT" -ne 0 ]; then
+        echo "setup.sh failed (exit \$SETUP_EXIT)" >> /meta/setup.log
         exit 90
-    }
+    fi
 fi
 $CLAUDE_CMD > /meta/output.json 2> /meta/stderr.log
 CLAUDE_EXIT=\$?

--- a/scripts/eval/tasks/02-fix-typo/expect.md
+++ b/scripts/eval/tasks/02-fix-typo/expect.md
@@ -1,0 +1,31 @@
+# 02-fix-typo
+
+## Purpose
+
+The first real capability task — tests whether the model can drive Claude Code through a complete read-edit-verify loop on a tiny, well-defined target. Exercises:
+
+- Workspace discovery (find README.md without being told where it is)
+- Reading a file's contents
+- Recognizing a typo without it being pointed out explicitly
+- Producing a correct file edit
+- Leaving the workspace in a state the score check will accept
+
+## Setup state
+
+A git repo at `/workspace/` with a single file `README.md` containing exactly:
+
+```
+# Hello Wrold
+```
+
+(committed; the typo is "Wrold" which should be "World")
+
+## Pass criteria
+
+`grep -q "Hello World" README.md` succeeds after the agent run. The score script enforces this automatically.
+
+Acceptable: any edit that produces a line containing "Hello World". The model doesn't have to remove the "#" or change anything else; only "Wrold" → "World" matters.
+
+## Notes
+
+Intentionally small enough that wall-clock cost stays bounded on slow CPU paths — useful as a sanity check on whether a model can drive Claude Code at all before investing time in heavier tasks.

--- a/scripts/eval/tasks/02-fix-typo/prompt.txt
+++ b/scripts/eval/tasks/02-fix-typo/prompt.txt
@@ -1,0 +1,1 @@
+Fix the typo in README.md.

--- a/scripts/eval/tasks/02-fix-typo/score.sh
+++ b/scripts/eval/tasks/02-fix-typo/score.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Pass if README.md contains "Hello World" (typo fixed). Runs in /workspace.
+set -e
+
+[ -f README.md ] || { echo "README.md missing"; exit 2; }
+grep -q "Hello World" README.md

--- a/scripts/eval/tasks/02-fix-typo/setup.sh
+++ b/scripts/eval/tasks/02-fix-typo/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Workspace setup for 02-fix-typo. Runs inside the agent container with cwd=/workspace.
+set -e
+
+git init -q
+git config user.email "eval@forge.local"
+git config user.name "Eval Setup"
+echo "# Hello Wrold" > README.md
+git add .
+git commit -qm "init"


### PR DESCRIPTION
## Summary

Extends the eval harness to support real capability tasks that need a workspace, and lands the first such task. Backward-compatible: existing tasks without `setup.sh`/`score.sh` (like `01-sanity-pong`) keep working unchanged.

## What's added to the task contract

Each task directory may now include:

| File | Optional | Purpose |
|------|----------|---------|
| `prompt.txt` | required | The user message to `claude -p` |
| `setup.sh` | yes | Runs in container before claude, `cwd=/workspace`. Populates the workspace. |
| `score.sh` | yes | Runs in container after claude, `cwd=/workspace`. Exit 0=pass, non-zero=fail. |
| `expect.md` | yes | Human-readable success criteria. |

Inside the container the task sees three mount points: `/task` (read-only task source), `/workspace` (writable, captured to results after), `/meta` (output collection). Details documented in `scripts/eval/README.md`.

## The first real task: `02-fix-typo`

Workspace: a git repo with `README.md` containing `# Hello Wrold`. Prompt: `Fix the typo in README.md.` Score: `grep -q "Hello World" README.md`. Exercises the full read-recognize-edit-verify loop on a target small enough to keep wall-clock cost bounded.

## End-to-end verification (live, on tesseract)

```
warmup duration: 344s
01-sanity-pong: 7s
02-fix-typo: 1764s [score: pass]
```

Resulting `meta.json` carries `"score":"pass","score_exit":0` and `workspace/README.md` reads `# Hello World` — the model successfully drove Claude Code through 3 tool-use turns to identify and fix the typo with 188 output tokens.

## Real-data finding for the matrix

The 02-fix-typo run took ~29 minutes for what's a trivial read-edit task. Each tool-use turn pays its own prefill against a growing context, so real-task wall-clock cost is an order of magnitude higher than the single-turn output rate suggested. This is important data for matrix sizing — real tasks ≠ "200 tokens × generation rate."

## Test plan

- [x] `bash -n` passes on `run-task.sh`
- [x] `01-sanity-pong` still works (backward compat for tasks without setup/score)
- [x] `02-fix-typo` runs end-to-end with `score: pass` on `qwen3-coder-32k`
- [x] `meta.json` schema includes the new `score` and `score_exit` fields
- [x] `workspace/` directory captures the final state correctly

## Follow-ups (separate PRs)

- More real tasks: `03-refactor-function`, `04-write-test`, `05-fix-bug-from-trace` — increasing complexity, same shape
- Update `docs/CLAUDE-CODE-LOCAL-MODELS.md` with real matrix results once a few models have been run against all tasks