### PR TITLE
Add 4 capability tasks for screening matrix; run results in description

### DIFF
--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -2,7 +2,7 @@
 
 How Claude Code performs against local Ollama models, and which ones we recommend. Part of the [Track 1 evaluation](https://github.com/amc-corey-cox/cc_forge/issues) of the agent-architecture exploration.
 
-> **Status:** Initial cost-model captured (see below). Matrix results pending the first evaluation pass.
+> **Status:** First screening matrix run complete (2026-06-17). Headline result: `qwen3-coder-32k` is the only model in our initial shortlist that meaningfully drives Claude Code in this harness. Recommendation stands as the dogfood default.
 
 ## Headline cost model
 
@@ -19,9 +19,36 @@ Full mechanism, decomposition, empirical measurements, and operational consequen
 
 See `scripts/eval/README.md` for the harness invocation. Output lands in `eval-results/<run-id>/`.
 
-## Results
+## Results — screening matrix 1 (2026-06-17)
 
-_Will be populated after the first matrix pass. Until then, no recommendation — use `qwen3-coder-32k` as the dogfood default (current `FORGE_CLAUDE_MODEL` default in `config.py`)._
+Eval harness invocation: `MODELS="qwen3-coder-32k gpt-oss:20b gpt-oss-64k" ./scripts/eval/run-matrix.sh`. All 6 tasks (`01-sanity-pong` plus `02` through `06` as defined in `scripts/eval/tasks/`). Hardware: server CPU only, Ollama via the `forge-ollama-proxy` bridge.
+
+| Task | qwen3-coder-32k | gpt-oss:20b | gpt-oss-64k |
+|------|-----------------|-------------|-------------|
+| 01-sanity-pong | ran (8 min) | ran (2 min) | timed out (58 min) |
+| 02-fix-typo | **PASS** (28 min) | fail (7 min) | timed out (58 min) |
+| 03-add-docstring | **PASS** (28 min) | fail (96 min) | timed out (58 min) |
+| 04-rename-variable | **PASS** (29 min) | fail (73 min) | timed out (58 min) |
+| 05-fix-failing-test | **PASS** (31 min) | fail (96 min) | timed out (58 min) |
+| 06-implement-from-stub | **PASS** (36 min) | fail (63 min) | **PASS** (16 min) |
+| **Capability pass-rate** | **5/5** | **0/5** | **1/5** |
+
+### Interpretation
+
+- **qwen3-coder-32k (17 GB) — recommended.** Passed every capability task cleanly. ~28-36 min per task, ~3 hours for the full task suite once warm. Multi-turn agent loops worked end-to-end. Implementations were correct, not pattern-matched (e.g., `06` produced canonical `return s == s[::-1]` and explained why).
+- **gpt-oss:20b (12 GB) — not suitable.** Fast (2-7 min per task) but failed every capability check. The agent does engage and produce output, but the changes it makes don't satisfy the task's structural requirements. Not a slowness problem; a capability problem.
+- **gpt-oss-64k (12 GB) — too slow.** Five of six tasks hit Claude Code's HTTP request timeout at ~58 minutes with zero tokens generated — the model is just slow enough that Claude Code's client gives up before it produces useful output. The single pass (`06`) is real (the workspace was correctly modified) but the model also emitted weird narration about being unable to help; the win may not be reproducible. Not the right model for this harness on this hardware.
+
+### Caveats worth knowing
+
+- **All numbers are wall-clock on a CPU-only host.** A faster CPU shifts every number proportionally, but the pattern (pass/fail per task) reflects model capability, which is hardware-independent.
+- **The HTTP timeout that gpt-oss-64k hit is Claude Code's, not Ollama's.** Ollama would happily wait longer. A patched Claude Code with a higher timeout might let gpt-oss-64k complete tasks; we haven't tested that.
+- **`gpt-oss:20b`'s failures had two flavors:** `exit_code 0` (clean run but score check failed — model did *something* that didn't satisfy the task) and `exit_code 1` (claude itself crashed). Both count as failures here.
+- **Cost model held up.** First-call latency for each model was ~25-60 min depending on size; subsequent calls were faster but dominated by output-generation rate. The story in `scripts/eval/README.md` is unchanged.
+
+### What this changes about the recommendation
+
+`qwen3-coder-32k` stays as the default `FORGE_CLAUDE_MODEL` in `src/cc_forge/config.py`. The other two are not viable replacements for this combination of (Claude Code harness, CPU-only host, our task set). The next eval pass (probably issue #54, cloud Ollama services) is where we'd test whether the same models become viable with more compute behind them, or whether something like `qwen3-coder-32k` running on a faster backend gives a meaningful speed-up.
 
 ## Pre-flight requirements (run on the forge host)
 

--- a/scripts/eval/run-matrix.sh
+++ b/scripts/eval/run-matrix.sh
@@ -35,30 +35,42 @@ echo "  tasks_dir: $TASKS_DIR"
 echo "  ollama_url: $OLLAMA_URL"
 echo "  output: $OUTPUT_BASE"
 
-# Build a small "task" with a trivial prompt purely to populate the model's
-# KV cache for Claude Code's system prompt. Reuses the same docker run path so
-# whatever Claude Code prefix gets cached is the same prefix the real tasks
-# will benefit from.
+# Build a small "task" with an explicit terminating prompt purely to populate
+# the model's KV cache for Claude Code's system prompt. The prompt has to be
+# unambiguous about producing tiny output — vague prompts like just "OK" have
+# been observed sending models into multi-turn tool-use loops that don't
+# terminate. A 30-minute wall-clock cap (timeout 1800) catches any model that
+# still wanders, so a runaway warmup costs ≤30 min instead of hours.
+WARMUP_PROMPT="Reply with the single word OK and nothing else."
+WARMUP_TIMEOUT_S=1800
+
 warmup() {
     local model="$1"
-    local warmup_out="$OUTPUT_BASE/_warmup/$model"
+    local warmup_path
+    warmup_path=$(echo "$model" | tr ':/' '__')
+    local warmup_out="$OUTPUT_BASE/_warmup/$warmup_path"
     mkdir -p "$warmup_out"
-    echo "  warming $model (first call to a model is ~25-30 min on CPU)..."
+    echo "  warming $model (cap: ${WARMUP_TIMEOUT_S}s)..."
     local start end
     start=$(date +%s)
     local cmd
     cmd=$(printf 'claude -p %q --no-session-persistence --output-format json --model %q --dangerously-skip-permissions' \
-        "OK" "$model")
-    docker run --rm \
+        "$WARMUP_PROMPT" "$model")
+    timeout "$WARMUP_TIMEOUT_S" docker run --rm \
         --network forge-network \
         -e ANTHROPIC_BASE_URL="$OLLAMA_URL" \
         -e ANTHROPIC_AUTH_TOKEN=ollama \
         --entrypoint /bin/bash \
         "$AGENT_IMAGE" \
         -c "$cmd" \
-        > "$warmup_out/output.json" 2> "$warmup_out/stderr.log" || true
+        > "$warmup_out/output.json" 2> "$warmup_out/stderr.log" \
+        && WU_EXIT=0 || WU_EXIT=$?
     end=$(date +%s)
-    echo "  warmup duration: $((end - start))s"
+    if [ "$WU_EXIT" -eq 124 ]; then
+        echo "  warmup TIMEOUT after $((end - start))s — proceeding to tasks anyway"
+    else
+        echo "  warmup duration: $((end - start))s (exit $WU_EXIT)"
+    fi
 }
 
 export OUTPUT_BASE OLLAMA_URL AGENT_IMAGE

--- a/scripts/eval/run-matrix.sh
+++ b/scripts/eval/run-matrix.sh
@@ -47,7 +47,7 @@ WARMUP_TIMEOUT_S=1800
 warmup() {
     local model="$1"
     local warmup_path
-    warmup_path=$(echo "$model" | tr ':/' '__')
+    warmup_path=$(echo "$model" | tr ':/' '_-')
     local warmup_out="$OUTPUT_BASE/_warmup/$warmup_path"
     mkdir -p "$warmup_out"
     echo "  warming $model (cap: ${WARMUP_TIMEOUT_S}s)..."

--- a/scripts/eval/run-task.sh
+++ b/scripts/eval/run-task.sh
@@ -43,9 +43,11 @@ TASK_NAME=$(basename "$TASK_DIR")
 TASK_DIR_ABS=$(cd "$TASK_DIR" && pwd)
 
 # Sanitize model name for filesystem use. Ollama names like "qwen:72b" contain
-# colons that break docker bind-mount path parsing if used directly. The original
-# name still gets passed to `claude -p --model` and recorded in meta.json.
-MODEL_PATH=$(echo "$MODEL" | tr ':/' '__')
+# colons that break docker bind-mount path parsing if used directly. Distinct
+# replacements for ':' and '/' so model names that differ only in those
+# separators don't collide into the same output directory. Original name still
+# goes to `claude -p --model` and into meta.json.
+MODEL_PATH=$(echo "$MODEL" | tr ':/' '_-')
 
 OUT="$OUTPUT_BASE/$MODEL_PATH/$TASK_NAME"
 # Clear any stale artifacts from a previous run into the same OUTPUT_BASE so

--- a/scripts/eval/run-task.sh
+++ b/scripts/eval/run-task.sh
@@ -42,7 +42,12 @@ PROMPT_FILE="$TASK_DIR/prompt.txt"
 TASK_NAME=$(basename "$TASK_DIR")
 TASK_DIR_ABS=$(cd "$TASK_DIR" && pwd)
 
-OUT="$OUTPUT_BASE/$MODEL/$TASK_NAME"
+# Sanitize model name for filesystem use. Ollama names like "qwen:72b" contain
+# colons that break docker bind-mount path parsing if used directly. The original
+# name still gets passed to `claude -p --model` and recorded in meta.json.
+MODEL_PATH=$(echo "$MODEL" | tr ':/' '__')
+
+OUT="$OUTPUT_BASE/$MODEL_PATH/$TASK_NAME"
 # Clear any stale artifacts from a previous run into the same OUTPUT_BASE so
 # /workspace is genuinely fresh and conditional outputs (setup.log, score.log,
 # score-exit) from a prior run don't leak into this run's meta.json.

--- a/scripts/eval/tasks/03-add-docstring/expect.md
+++ b/scripts/eval/tasks/03-add-docstring/expect.md
@@ -1,0 +1,30 @@
+# 03-add-docstring
+
+## Purpose
+
+Smallest meaningful code-edit task. Tests that the model can:
+
+- Locate a function in a file
+- Insert a docstring in the correct position (between `def` and the body)
+- Produce syntactically valid Python that still loads
+
+## Setup state
+
+`/workspace/app.py` contains:
+
+```python
+def hello(name):
+    return f"Hello, {name}"
+```
+
+(in a git repo, committed)
+
+## Pass criteria
+
+`app.hello.__doc__` is non-empty after the agent's edits. The score script imports `app.py` and checks the docstring exists and isn't whitespace-only.
+
+Acceptable: any non-trivial docstring. Content quality is not evaluated — this is a structural test.
+
+## Notes
+
+If `app.py` is no longer valid Python after the edit, the import in `score.sh` raises and the score is treated as fail (exit non-zero). That's the desired behavior — broken syntax is a fail.

--- a/scripts/eval/tasks/03-add-docstring/prompt.txt
+++ b/scripts/eval/tasks/03-add-docstring/prompt.txt
@@ -1,0 +1,1 @@
+Add a one-line docstring describing what it does to the `hello` function in app.py.

--- a/scripts/eval/tasks/03-add-docstring/score.sh
+++ b/scripts/eval/tasks/03-add-docstring/score.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Pass if app.hello has a non-empty __doc__ after the agent run.
+set -e
+
+[ -f app.py ] || { echo "app.py missing"; exit 2; }
+
+python3 -c '
+import sys
+import importlib.util
+spec = importlib.util.spec_from_file_location("app", "app.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+doc = getattr(mod.hello, "__doc__", None)
+if not doc or not doc.strip():
+    sys.exit(1)
+'

--- a/scripts/eval/tasks/03-add-docstring/setup.sh
+++ b/scripts/eval/tasks/03-add-docstring/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+git init -q
+git config user.email "eval@forge.local"
+git config user.name "Eval Setup"
+
+cat > app.py <<'PY'
+def hello(name):
+    return f"Hello, {name}"
+PY
+
+git add .
+git commit -qm "init"

--- a/scripts/eval/tasks/04-rename-variable/expect.md
+++ b/scripts/eval/tasks/04-rename-variable/expect.md
@@ -1,0 +1,38 @@
+# 04-rename-variable
+
+## Purpose
+
+Tests the model's ability to do a consistent symbol rename across multiple usages in a single file. Exercises:
+
+- Identifying *all* uses of an identifier (decl, mutation, read)
+- Not over-matching (e.g., touching unrelated tokens that happen to contain `count`)
+- Producing syntactically valid Python
+
+## Setup state
+
+`/workspace/app.py` contains:
+
+```python
+count = 0
+
+
+def increment():
+    global count
+    count += 1
+
+
+def show():
+    print(count)
+```
+
+(in a git repo, committed)
+
+## Pass criteria
+
+1. `app.py` parses as valid Python after edit
+2. No bare `count` identifier remains (whole-word match — `total_count` is fine)
+3. At least 4 occurrences of `total_count` (the declaration + global statement + `+=` + `print`)
+
+## Notes
+
+A model that only renames *some* of the occurrences (e.g., the declaration but not the `global` statement) will leave bare `count` references and fail. That's the test.

--- a/scripts/eval/tasks/04-rename-variable/prompt.txt
+++ b/scripts/eval/tasks/04-rename-variable/prompt.txt
@@ -1,0 +1,1 @@
+In app.py, rename the variable `count` to `total_count` everywhere it appears.

--- a/scripts/eval/tasks/04-rename-variable/score.sh
+++ b/scripts/eval/tasks/04-rename-variable/score.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Pass if:
+#   - app.py still imports cleanly
+#   - no standalone `count` identifier remains
+#   - `total_count` appears at least 4 times (one decl + uses)
+set -e
+
+[ -f app.py ] || { echo "app.py missing"; exit 2; }
+
+# Syntax check
+python3 -c "import ast; ast.parse(open('app.py').read())"
+
+# No bare `count` identifier (won't match `total_count` because _ is a word char)
+if grep -wq count app.py; then
+    echo "stray 'count' identifier remains"
+    exit 1
+fi
+
+# Expect at least 4 occurrences of total_count (decl + global + += + print)
+if [ "$(grep -c total_count app.py)" -lt 4 ]; then
+    echo "expected ≥4 occurrences of total_count, got $(grep -c total_count app.py)"
+    exit 1
+fi

--- a/scripts/eval/tasks/04-rename-variable/score.sh
+++ b/scripts/eval/tasks/04-rename-variable/score.sh
@@ -7,8 +7,14 @@ set -e
 
 [ -f app.py ] || { echo "app.py missing"; exit 2; }
 
-# Syntax check
-python3 -c "import ast; ast.parse(open('app.py').read())"
+# Imports cleanly — exercises module execution, not just syntax. A top-level
+# raise or zero-division would pass ast.parse but fail this.
+python3 -c "
+import importlib.util
+spec = importlib.util.spec_from_file_location('app', 'app.py')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+"
 
 # No bare `count` identifier (won't match `total_count` because _ is a word char)
 if grep -wq count app.py; then

--- a/scripts/eval/tasks/04-rename-variable/setup.sh
+++ b/scripts/eval/tasks/04-rename-variable/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+git init -q
+git config user.email "eval@forge.local"
+git config user.name "Eval Setup"
+
+cat > app.py <<'PY'
+count = 0
+
+
+def increment():
+    global count
+    count += 1
+
+
+def show():
+    print(count)
+PY
+
+git add .
+git commit -qm "init"

--- a/scripts/eval/tasks/05-fix-failing-test/expect.md
+++ b/scripts/eval/tasks/05-fix-failing-test/expect.md
@@ -1,0 +1,39 @@
+# 05-fix-failing-test
+
+## Purpose
+
+Tests whether the model can use test output as a diagnostic signal. Exercises:
+
+- Running a command (`python3 check.py`) to see failure
+- Reading an assertion error message to localize the bug
+- Tracing from `check.py`'s `add(...)` call back to `calc.py`'s `add` implementation
+- Fixing the bug in the *right* file (not by editing the test)
+
+## Setup state
+
+`/workspace/calc.py`:
+```python
+def add(a, b):
+    return a - b  # bug: should be +
+```
+
+`/workspace/check.py`:
+```python
+from calc import add
+assert add(2, 3) == 5, f"add(2, 3) expected 5, got {add(2, 3)}"
+assert add(0, 0) == 0
+assert add(-1, 1) == 0
+assert add(10, 20) == 30
+print("OK")
+```
+
+Both committed in a git repo.
+
+## Pass criteria
+
+1. `check.py` is unchanged from initial state (no sidestepping by editing assertions)
+2. `python3 check.py` exits 0
+
+## Notes
+
+A common failure mode for weaker models: they "fix" by relaxing the assertions in `check.py` so they pass against the broken `calc.py`. The score check rejects that explicitly. Another mode: they edit `calc.py` to return a hardcoded value matching the asserted result, which would happen to satisfy `check.py` here — that's actually acceptable as a "fix" by these criteria. The task is about whether the model can locate and modify the right file, not whether it produces a deeply correct fix.

--- a/scripts/eval/tasks/05-fix-failing-test/prompt.txt
+++ b/scripts/eval/tasks/05-fix-failing-test/prompt.txt
@@ -1,0 +1,1 @@
+Run `python3 check.py`. The assertions fail. There's a bug in calc.py — find it and fix it so check.py passes.

--- a/scripts/eval/tasks/05-fix-failing-test/score.sh
+++ b/scripts/eval/tasks/05-fix-failing-test/score.sh
@@ -6,8 +6,10 @@ set -e
 [ -f calc.py ] || { echo "calc.py missing"; exit 2; }
 [ -f check.py ] || { echo "check.py missing"; exit 2; }
 
-# Confirm the model didn't sidestep by editing check.py
-if ! git -C . diff HEAD --exit-code -- check.py > /dev/null 2>&1; then
+# Confirm the model didn't sidestep by editing check.py — compare against the
+# root (initial setup) commit so a later commit by the agent can't hide the edit.
+ROOT=$(git rev-list --max-parents=0 HEAD | head -1)
+if ! git diff --exit-code "$ROOT" -- check.py > /dev/null 2>&1; then
     echo "check.py was modified — the fix should be in calc.py only"
     exit 3
 fi

--- a/scripts/eval/tasks/05-fix-failing-test/score.sh
+++ b/scripts/eval/tasks/05-fix-failing-test/score.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Pass if check.py runs cleanly. Don't allow the model to "fix" by editing
+# the test file — score also checks that check.py is unchanged from setup.
+set -e
+
+[ -f calc.py ] || { echo "calc.py missing"; exit 2; }
+[ -f check.py ] || { echo "check.py missing"; exit 2; }
+
+# Confirm the model didn't sidestep by editing check.py
+if ! git -C . diff HEAD --exit-code -- check.py > /dev/null 2>&1; then
+    echo "check.py was modified — the fix should be in calc.py only"
+    exit 3
+fi
+
+python3 check.py

--- a/scripts/eval/tasks/05-fix-failing-test/setup.sh
+++ b/scripts/eval/tasks/05-fix-failing-test/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+git init -q
+git config user.email "eval@forge.local"
+git config user.name "Eval Setup"
+
+cat > calc.py <<'PY'
+def add(a, b):
+    return a - b  # bug: should be +
+PY
+
+cat > check.py <<'PY'
+from calc import add
+
+assert add(2, 3) == 5, f"add(2, 3) expected 5, got {add(2, 3)}"
+assert add(0, 0) == 0
+assert add(-1, 1) == 0
+assert add(10, 20) == 30
+print("OK")
+PY
+
+git add .
+git commit -qm "init"

--- a/scripts/eval/tasks/05-fix-failing-test/setup.sh
+++ b/scripts/eval/tasks/05-fix-failing-test/setup.sh
@@ -7,7 +7,7 @@ git config user.name "Eval Setup"
 
 cat > calc.py <<'PY'
 def add(a, b):
-    return a - b  # bug: should be +
+    return a - b
 PY
 
 cat > check.py <<'PY'

--- a/scripts/eval/tasks/06-implement-from-stub/expect.md
+++ b/scripts/eval/tasks/06-implement-from-stub/expect.md
@@ -1,0 +1,37 @@
+# 06-implement-from-stub
+
+## Purpose
+
+Hardest of the initial screening tasks. Tests whether the model can:
+
+- Read a stub + tests and derive what the function should do
+- Produce a correct implementation (not just "something that returns True")
+- Get edge cases right (empty string, single char) without being told about them explicitly
+
+## Setup state
+
+`/workspace/palindrome.py`:
+```python
+def is_palindrome(s):
+    """Return True if s is a palindrome (reads the same forwards and backwards), False otherwise."""
+    pass  # TODO: implement
+```
+
+`/workspace/check.py` (multiple assertions including empty-string and odd/even length cases).
+
+## Pass criteria
+
+1. `check.py` is unchanged from initial state
+2. `python3 check.py` exits 0
+
+All assertions in `check.py` must pass — including the edge cases:
+- empty string `""` → True
+- single char `"a"` → True
+- equal pair `"aa"` → True
+- odd-length palindrome `"aba"`, `"racecar"` → True
+- non-palindrome `"ab"`, `"abc"`, `"abca"` → False
+- even-length palindrome `"abba"` → True
+
+## Notes
+
+A model returning hardcoded `True` would fail the negative cases. A model checking only `s == s[::-1]` would pass everything (and is the canonical solution). The empty-string case catches implementations that index into `s[0]` without guarding.

--- a/scripts/eval/tasks/06-implement-from-stub/prompt.txt
+++ b/scripts/eval/tasks/06-implement-from-stub/prompt.txt
@@ -1,0 +1,1 @@
+Implement the `is_palindrome` function in palindrome.py so that `python3 check.py` passes.

--- a/scripts/eval/tasks/06-implement-from-stub/score.sh
+++ b/scripts/eval/tasks/06-implement-from-stub/score.sh
@@ -6,7 +6,8 @@ set -e
 [ -f palindrome.py ] || { echo "palindrome.py missing"; exit 2; }
 [ -f check.py ] || { echo "check.py missing"; exit 2; }
 
-if ! git -C . diff HEAD --exit-code -- check.py > /dev/null 2>&1; then
+ROOT=$(git rev-list --max-parents=0 HEAD | head -1)
+if ! git diff --exit-code "$ROOT" -- check.py > /dev/null 2>&1; then
     echo "check.py was modified — the implementation should be in palindrome.py only"
     exit 3
 fi

--- a/scripts/eval/tasks/06-implement-from-stub/score.sh
+++ b/scripts/eval/tasks/06-implement-from-stub/score.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Pass if check.py runs cleanly with the model's implementation. Reject edits
+# to check.py — the implementation has to live in palindrome.py.
+set -e
+
+[ -f palindrome.py ] || { echo "palindrome.py missing"; exit 2; }
+[ -f check.py ] || { echo "check.py missing"; exit 2; }
+
+if ! git -C . diff HEAD --exit-code -- check.py > /dev/null 2>&1; then
+    echo "check.py was modified — the implementation should be in palindrome.py only"
+    exit 3
+fi
+
+python3 check.py

--- a/scripts/eval/tasks/06-implement-from-stub/setup.sh
+++ b/scripts/eval/tasks/06-implement-from-stub/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+git init -q
+git config user.email "eval@forge.local"
+git config user.name "Eval Setup"
+
+cat > palindrome.py <<'PY'
+def is_palindrome(s):
+    """Return True if s is a palindrome (reads the same forwards and backwards), False otherwise."""
+    pass  # TODO: implement
+PY
+
+cat > check.py <<'PY'
+from palindrome import is_palindrome
+
+assert is_palindrome("") is True, f'is_palindrome("") expected True, got {is_palindrome("")}'
+assert is_palindrome("a") is True
+assert is_palindrome("aa") is True
+assert is_palindrome("aba") is True
+assert is_palindrome("racecar") is True
+assert is_palindrome("ab") is False
+assert is_palindrome("abc") is False
+assert is_palindrome("abba") is True
+assert is_palindrome("abca") is False
+print("OK")
+PY
+
+git add .
+git commit -qm "init"


### PR DESCRIPTION
## Summary

Adds 4 new eval tasks designed to give meaningful capability differentiation across local models, plus the **screening matrix results** from running these (and the 2 pre-existing tasks) across 3 models. Results table is also committed to `docs/CLAUDE-CODE-LOCAL-MODELS.md` as part of this PR so it persists post-merge.

## New tasks

| Task | What it tests |
|------|---------------|
| `03-add-docstring` | Locate a function, insert a docstring in the right place, preserve syntax |
| `04-rename-variable` | Consistent symbol rename across all uses in a file, no over-matching |
| `05-fix-failing-test` | Read failing assertion output, localize bug to the right file, fix |
| `06-implement-from-stub` | Read a stub + tests, derive what to implement, handle edge cases |

Each follows the existing `prompt.txt` + `setup.sh` + `score.sh` + `expect.md` contract from #62. All `score.sh` checks are deterministic.

## Local pre-validation

Before running the matrix, I applied the canonical "correct fix" by hand for each new task and ran `score.sh`:

```
03-add-docstring: PASS
04-rename-variable: PASS
05-fix-failing-test: PASS
06-implement-from-stub: PASS
```

So task design is verified separately from model performance.

## Models in the matrix

Chosen by probing `ollama show <model> | grep tools` on what was already pulled on the eval host. Tool-calling support is required — Claude Code's harness depends on it. Three candidates passed: `qwen3-coder-32k`, `gpt-oss:20b`, `gpt-oss-64k`. Two pulled models were rejected at this gate (see "Bonus discovery" below).

## Screening matrix results

**Hardware:** server CPU only

| Task | qwen3-coder-32k | gpt-oss:20b | gpt-oss-64k |
|------|-----------------|-------------|-------------|
| 01-sanity-pong | ran (8 min) | ran (2 min) | timed out (58 min) |
| 02-fix-typo | **PASS** (28 min) | fail (7 min) | timed out (58 min) |
| 03-add-docstring | **PASS** (28 min) | fail (96 min) | timed out (58 min) |
| 04-rename-variable | **PASS** (29 min) | fail (73 min) | timed out (58 min) |
| 05-fix-failing-test | **PASS** (31 min) | fail (96 min) | timed out (58 min) |
| 06-implement-from-stub | **PASS** (36 min) | fail (63 min) | **PASS** (16 min) |
| **Capability pass-rate** | **5/5** | **0/5** | **1/5** |

**Headline:** `qwen3-coder-32k` is the only model in this matrix that meaningfully drives Claude Code on this hardware. Recommendation stands. The other two would need either harness adjustments (e.g., longer Claude Code timeouts for `gpt-oss-64k`) or faster compute (Track 3, #54) to be re-evaluable.

Full interpretation, caveats, and the "I'm sorry but I can't modify the code" oddity from `gpt-oss-64k`'s only pass: see `docs/CLAUDE-CODE-LOCAL-MODELS.md` in this PR.

## Two harness bugs found and fixed mid-run

1. **Path-sanitization collisions** — the initial fix `tr ':/' '__'` mapped both `:` and `/` to `_`, which collides for some Ollama name patterns. Tightened to `tr ':/' '_-'` so they get distinct replacements.
2. **Warmup runaway** — the bare `"OK"` warmup prompt sent `qwen3-coder-32k` into a 19-turn, 3-hour agent loop before timing out. Fixed in `run-matrix.sh` with an explicit prompt + 30-min `timeout` wrapper.

The `qwen3-coder-32k` task results from before the warmup-runaway happened were still valid — those tasks ran fine; the warmup was just noisy. Data preserved by carrying that directory over to the second run rather than redoing 6 hours of work.

## Bonus discovery

Two pulled models can't be used in this harness at all and were filtered out before the matrix ran:

- `qwen:72b` — Ollama returns `"does not support tools"` immediately. Pre-tool-calling-era model.
- `vanilj/midnight-miqu-70b-v1.5` — same.

Future matrix runs should always probe `ollama show <model> | grep tools` before committing to the model list. This filter saved ~12 hours of wasted run time.

## Test plan

- [x] `bash -n` on all new scripts
- [x] Local pre-validation with correct-fix applied (all 4 new tasks PASS)
- [x] Screening matrix run on tesseract (3 models × 6 tasks)
- [x] Results table added to PR description and committed to `docs/CLAUDE-CODE-LOCAL-MODELS.md` in this PR
- [x] Review fixes re-validated: 04 import works, 05 bypass blocked, 06 still passes