### PR TITLE
Harness-agnostic container agent instructions (docker/AGENTS.md, inject for all agents)

### DIFF
--- a/docker/AGENTS.md
+++ b/docker/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Environment Notes
+
+For pull request and issue operations, prefer `gh` — it's the only tool here pre-configured with the credentials needed to reach Forgejo and GitHub. `gh` in this environment is a custom shim that attempts to behave like the real GitHub CLI but routes commands to your workspace's Forgejo or to read-only GitHub as appropriate. Output is always the underlying API's JSON response — Forgejo's or GitHub's — not `gh`'s human-readable text or `--json` shape. Use the JSON as-is; don't restructure or reformat it.

--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -1,3 +1,1 @@
-# Agent Environment Notes
-
-For pull request and issue operations, prefer `gh` — it's the only tool here pre-configured with the credentials needed to reach Forgejo and GitHub. `gh` in this environment is a custom shim that attempts to behave like the real GitHub CLI but routes commands to your workspace's Forgejo or to read-only GitHub as appropriate. Output is always the underlying API's JSON response — Forgejo's or GitHub's — not `gh`'s human-readable text or `--json` shape. Use the JSON as-is; don't restructure or reformat it.
+AGENTS.md

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -366,9 +366,11 @@ def run_agent_container(
     try:
         _inject_git_credentials(container, config)
         _inject_shim_credentials(container, config)
-        _inject_agent_instructions(container, config)
         if claude_passthrough:
             _copy_claude_config(container, config)
+        # After the Claude state restore, so the canonical instructions always win
+        # (restored state can carry a stale ~/.claude/CLAUDE.md from a prior session).
+        _inject_agent_instructions(container, config)
         container.start()
     except Exception:
         try:

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -152,6 +152,35 @@ def _add_tar_dir(tar, name: str) -> None:
     tar.addfile(info)
 
 
+def _inject_agent_instructions(container, config: ForgeConfig) -> None:
+    """Inject forge's agent instructions into the container, for any harness.
+
+    Canonical source is docker/AGENTS.md (CLAUDE.md symlinks to it). The instructions
+    describe the forge environment, so they live in the agent's home — not the cloned
+    repo — and are surfaced where each supported harness reads them:
+      - ~/.claude/CLAUDE.md     (Claude)
+      - ~/AGENTS.md             (canonical; the cross-harness convention)
+      - ~/.aider.conf.yml       (aider reads AGENTS.md as a read-only context file)
+    """
+    import io
+    import tarfile
+
+    docker_dir = Path(config.compose_file).parent
+    agents_md = docker_dir / "AGENTS.md"
+    if not agents_md.is_file():
+        return
+    data = agents_md.read_bytes()
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        _add_tar_dir(tar, ".claude/")
+        _add_tar_file(tar, ".claude/CLAUDE.md", data)
+        _add_tar_file(tar, "AGENTS.md", data)
+        _add_tar_file(tar, ".aider.conf.yml", b"read:\n  - /home/agent/AGENTS.md\n")
+    buf.seek(0)
+    container.put_archive("/home/agent", buf)
+
+
 def _copy_claude_config(container, config: ForgeConfig) -> None:
     """Copy Claude config into the container.
 
@@ -186,13 +215,6 @@ def _copy_claude_config(container, config: ForgeConfig) -> None:
             # Inject credentials once (saved-preferred, host fallback)
             _add_tar_file(tar, ".claude/.credentials.json",
                           cred_path.read_bytes(), mode=0o600)
-
-        # Forge-specific agent CLAUDE.md (from docker/ directory, not host ~/.claude/)
-        docker_dir = Path(config.compose_file).parent
-        agent_claude_md = docker_dir / "CLAUDE.md"
-        if agent_claude_md.is_file():
-            _add_tar_file(tar, ".claude/CLAUDE.md",
-                          agent_claude_md.read_bytes())
 
         # $HOME/.claude.json — onboarding bypass + saved state
         # hasCompletedOnboarding lives here (NOT in settings.json)
@@ -344,6 +366,7 @@ def run_agent_container(
     try:
         _inject_git_credentials(container, config)
         _inject_shim_credentials(container, config)
+        _inject_agent_instructions(container, config)
         if claude_passthrough:
             _copy_claude_config(container, config)
         container.start()

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -300,23 +300,22 @@ class TestCopyClaudeConfig:
         assert claude_dir.mode == 0o755
         assert claude_dir.uid == AGENT_UID
 
-    def test_claude_md_injected_from_docker_dir(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("cc_forge.docker._forge_claude_state_dir", lambda: tmp_path / "nonexistent")
-
+    def test_agent_instructions_injected_for_all_harnesses(self, tmp_path):
         docker_dir = tmp_path / "docker"
         docker_dir.mkdir()
-        (docker_dir / "CLAUDE.md").write_bytes(b"# Agent instructions")
+        (docker_dir / "AGENTS.md").write_bytes(b"# Agent instructions")
 
-        config = _make_config(
-            claude_api_key="sk-test",
-            compose_file=str(docker_dir / "docker-compose.yml"),
-        )
+        config = _make_config(compose_file=str(docker_dir / "docker-compose.yml"))
         container = self._capture_container()
 
-        _copy_claude_config(container, config)
+        from cc_forge.docker import _inject_agent_instructions
+        _inject_agent_instructions(container, config)
 
-        content = self._get_tar_content(container, ".claude/CLAUDE.md")
-        assert content == b"# Agent instructions"
+        # Claude reads ~/.claude/CLAUDE.md; the canonical AGENTS.md lives in home;
+        # aider is pointed at it via ~/.aider.conf.yml.
+        assert self._get_tar_content(container, ".claude/CLAUDE.md") == b"# Agent instructions"
+        assert self._get_tar_content(container, "AGENTS.md") == b"# Agent instructions"
+        assert b"/home/agent/AGENTS.md" in self._get_tar_content(container, ".aider.conf.yml")
 
 
 class TestInjectGitCredentials:
@@ -503,7 +502,8 @@ class TestRunAgentContainer:
         client.containers.create.return_value = container
 
         with patch("cc_forge.docker._docker_client", return_value=client), \
-                patch("cc_forge.docker._copy_claude_config"):
+                patch("cc_forge.docker._copy_claude_config"), \
+                patch("cc_forge.docker._inject_agent_instructions"):
             from cc_forge.docker import run_agent_container
             result = run_agent_container(
                 config,
@@ -555,6 +555,22 @@ class TestRunAgentContainer:
         _, container, _ = self._run()
         # put_archive should be called for git credentials
         container.put_archive.assert_called()
+
+    def test_agent_instructions_injected_for_non_passthrough(self):
+        # The instructions must reach every harness, not just claude_passthrough.
+        config = _make_config()
+        client = MagicMock()
+        client.images.get.return_value = True
+        client.containers.create.return_value = MagicMock(id="x")
+        with patch("cc_forge.docker._docker_client", return_value=client), \
+                patch("cc_forge.docker._copy_claude_config"), \
+                patch("cc_forge.docker._inject_agent_instructions") as inject:
+            from cc_forge.docker import run_agent_container
+            run_agent_container(
+                config, repo_url="http://localhost:3000/u/r.git",
+                branch="main", repo_name="repo", claude_passthrough=False,
+            )
+        inject.assert_called_once()
 
 
 class TestSaveClaudeCredentials:

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -572,6 +572,24 @@ class TestRunAgentContainer:
             )
         inject.assert_called_once()
 
+    def test_instructions_injected_after_claude_state_in_passthrough(self):
+        # Canonical instructions must win over restored (possibly stale) Claude state.
+        config = _make_config()
+        client = MagicMock()
+        client.images.get.return_value = True
+        client.containers.create.return_value = MagicMock(id="x")
+        manager = MagicMock()
+        with patch("cc_forge.docker._docker_client", return_value=client), \
+                patch("cc_forge.docker._copy_claude_config", manager.copy), \
+                patch("cc_forge.docker._inject_agent_instructions", manager.inject):
+            from cc_forge.docker import run_agent_container
+            run_agent_container(
+                config, repo_url="http://localhost:3000/u/r.git",
+                branch="main", repo_name="repo", claude_passthrough=True,
+            )
+        order = [c[0] for c in manager.mock_calls]
+        assert order.index("copy") < order.index("inject")
+
 
 class TestSaveClaudeCredentials:
     """Tests for save_claude_credentials state extraction."""


### PR DESCRIPTION
## Summary

Makes the **container** agent instructions harness-agnostic — the mechanics half of #55. Forge-spawned agents now get their environment instructions regardless of which harness (`--agent`) or backend runs, instead of only Claude-passthrough sessions. The global-prompt *content* (review rounds, complexity audit) is a deliberate follow-up; this PR is structure only.

## The problem

`docker/CLAUDE.md` was Claude-named and injected solely inside `_copy_claude_config` (`docker.py`), which runs **only when `claude_passthrough`**. So an aider or Claude-via-Ollama session got **no** environment instructions at all, and the file was Claude-specific — even though `_build_agent_cmd` already supports `claude` and `aider`.

## What changed

- **`docker/CLAUDE.md` → `docker/AGENTS.md`** (canonical) + `docker/CLAUDE.md` symlink → `AGENTS.md`, mirroring the repo root.
- **`_inject_agent_instructions()`** — lifted the injection out of the passthrough-only path into a shared step called for **every** agent in `run_agent_container` (next to the git/shim credential injection).
- The instructions describe the **forge environment**, so they go to the agent's **home** (not `/workspace/repo`, which is the cloned repo the agent could commit into), surfaced where each harness reads them:

  | Harness | Reads | Injected as |
  |---|---|---|
  | Claude | `~/.claude/CLAUDE.md` | unchanged mechanism |
  | cross-tool | `AGENTS.md` | `~/AGENTS.md` (canonical) |
  | aider | does *not* read CLAUDE.md | `~/.aider.conf.yml` (`read: [/home/agent/AGENTS.md]`) |

## Tests

- [x] 142 unit tests pass — `_inject_agent_instructions` places all three files; `run_agent_container` injects even when **not** passthrough (the core fix).

## Test plan

- [ ] **Live: aider actually loads `~/.aider.conf.yml` `read:`** — verified against aider's documented config, not a running session. Needs an image rebuild + a real aider session on tesseract to confirm. (The Claude path is unchanged from what already works.)

## Not in this PR

- The global-prompt **content** — operating philosophy, multi-round review, complexity audit — written into `docker/AGENTS.md` as the next focused pass.

Part of #55.
