### PR TITLE
Forge agent global prompt + self-review/complexity-audit commands

### DIFF
--- a/docker/AGENTS.md
+++ b/docker/AGENTS.md
@@ -1,3 +1,49 @@
-# Agent Environment Notes
+# Forge Agent Guide
 
-For pull request and issue operations, prefer `gh` — it's the only tool here pre-configured with the credentials needed to reach Forgejo and GitHub. `gh` in this environment is a custom shim that attempts to behave like the real GitHub CLI but routes commands to your workspace's Forgejo or to read-only GitHub as appropriate. Output is always the underlying API's JSON response — Forgejo's or GitHub's — not `gh`'s human-readable text or `--json` shape. Use the JSON as-is; don't restructure or reformat it.
+You are an autonomous coding agent working inside a forge container: an isolated
+sandbox holding a clone of one repository at `/workspace/repo`. Do the task, then hand
+it back as a pull request.
+
+## Environment
+
+Use `gh` for anything involving pull requests, issues, or the remote repository — it's
+the tool here pre-configured with the right credentials, and it knows where each
+command should go, so you don't have to. Its output is the raw API JSON response; use
+it as-is rather than reformatting it.
+
+## How to work
+
+- Understand before you change. Read the relevant code and the task until you can say,
+  in a sentence, what "done" means.
+- Make the smallest change that fully solves the task. Prefer editing existing code
+  over adding new structure.
+- Leave unrelated code alone. A focused diff is easier to review and to trust.
+
+## Review your own work
+
+Before you open a PR, run two checks on your change — in order, every time:
+
+1. **`/self-review`** — confirm it does what the task asked, touches only what it needs,
+   and reads clearly.
+2. **`/complexity-audit`** — confirm it isn't more complex than the problem requires.
+
+Act on what each turns up, then review again. (No such commands in your environment? Do
+the same two checks by hand.) This single-agent discipline is the seed of forge's
+planned review teams — for now, you are all of them.
+
+## Finish with a pull request
+
+When the work is done, open a PR with `gh`:
+
+- A clear, specific title.
+- A description of **what** changed and **why** — enough that a reviewer who hasn't
+  watched you work can understand the change and decide to merge it.
+
+The PR is the deliverable, and its description is what lets the work be carried onward.
+Write it for the human who will read it.
+
+## Conventions
+
+- Match the existing style of the code you're editing.
+- Keep commit messages to one concise line.
+- Never commit secrets or credentials.

--- a/docker/commands/complexity-audit.md
+++ b/docker/commands/complexity-audit.md
@@ -1,0 +1,25 @@
+---
+description: Audit your change for complexity that isn't earning its keep
+---
+
+Look at the change you just made through the lens of the **complexity-to-utility
+trade-off**. It's easy to add complexity quickly without proportional gains in utility
+— audit your own diff with fresh eyes and flag anything where the complexity isn't
+worth it.
+
+Look for:
+
+1. **Needless abstraction** — layers, wrappers, or generality beyond what the task
+   actually needs.
+2. **Should be combined** — pieces you split apart that share so much context they'd be
+   simpler as one.
+3. **Should be split** — anything you made do too many unrelated jobs.
+4. **Overguarding** — handling for edge cases that are vanishingly unlikely or
+   low-impact, obscuring the happy path.
+5. **Overtesting** — tests that lock in implementation details rather than catch real
+   bugs, or that overlap heavily.
+6. **Dead or speculative code** — anything unused or built for a future that hasn't
+   arrived.
+
+Be direct — "delete this" beats "consider simplifying." Make the simplifications worth
+making before you open the PR.

--- a/docker/commands/self-review.md
+++ b/docker/commands/self-review.md
@@ -1,0 +1,24 @@
+---
+description: Review your own change before opening a pull request
+---
+
+Review the change you just made as if a colleague wrote it and you're deciding whether
+to approve it. Look at your diff against the branch you started from.
+
+First, the question that matters most: **did you deliver what the task asked, and can
+you prove it?** Be suspicious of your own work — it's easy to generate plausible change
+that drifts off the goal.
+
+- Is the core deliverable actually done, or did you build helpers, scaffolding, or
+  tangential tooling around a goal that's still unproven?
+- Is it backed by a test that would fail if the change were wrong — not just a manual
+  "looks right"?
+
+Then check the change itself:
+
+1. **Correct** — does it handle the main path and the edges? Run the tests.
+2. **Focused** — did you change only what the task needs? Remove or split out the rest.
+3. **Clear** — will the next person understand it from the code or a brief comment?
+4. **Safe** — no secrets committed, no obvious security hole in what you touched.
+
+If anything is wrong, incomplete, or murky, fix it and review again before opening the PR.

--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -161,6 +161,10 @@ def _inject_agent_instructions(container, config: ForgeConfig) -> None:
       - ~/.claude/CLAUDE.md     (Claude)
       - ~/AGENTS.md             (canonical; the cross-harness convention)
       - ~/.aider.conf.yml       (aider reads AGENTS.md as a read-only context file)
+
+    Any docker/commands/*.md are also injected to ~/.claude/commands/ so command-capable
+    harnesses can run them (e.g. the /self-review and /complexity-audit steps AGENTS.md
+    requires before opening a PR).
     """
     import io
     import tarfile
@@ -177,6 +181,12 @@ def _inject_agent_instructions(container, config: ForgeConfig) -> None:
         _add_tar_file(tar, ".claude/CLAUDE.md", data)
         _add_tar_file(tar, "AGENTS.md", data)
         _add_tar_file(tar, ".aider.conf.yml", b"read:\n  - /home/agent/AGENTS.md\n")
+
+        commands_dir = docker_dir / "commands"
+        if commands_dir.is_dir():
+            _add_tar_dir(tar, ".claude/commands/")
+            for cmd in sorted(commands_dir.glob("*.md")):
+                _add_tar_file(tar, f".claude/commands/{cmd.name}", cmd.read_bytes())
     buf.seek(0)
     container.put_archive("/home/agent", buf)
 

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -304,6 +304,9 @@ class TestCopyClaudeConfig:
         docker_dir = tmp_path / "docker"
         docker_dir.mkdir()
         (docker_dir / "AGENTS.md").write_bytes(b"# Agent instructions")
+        commands_dir = docker_dir / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "self-review.md").write_bytes(b"# self review")
 
         config = _make_config(compose_file=str(docker_dir / "docker-compose.yml"))
         container = self._capture_container()
@@ -316,6 +319,8 @@ class TestCopyClaudeConfig:
         assert self._get_tar_content(container, ".claude/CLAUDE.md") == b"# Agent instructions"
         assert self._get_tar_content(container, "AGENTS.md") == b"# Agent instructions"
         assert b"/home/agent/AGENTS.md" in self._get_tar_content(container, ".aider.conf.yml")
+        # commands land in ~/.claude/commands/ for command-capable harnesses
+        assert self._get_tar_content(container, ".claude/commands/self-review.md") == b"# self review"
 
 
 class TestInjectGitCredentials:

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -307,6 +307,7 @@ class TestCopyClaudeConfig:
         commands_dir = docker_dir / "commands"
         commands_dir.mkdir()
         (commands_dir / "self-review.md").write_bytes(b"# self review")
+        (commands_dir / "complexity-audit.md").write_bytes(b"# complexity audit")
 
         config = _make_config(compose_file=str(docker_dir / "docker-compose.yml"))
         container = self._capture_container()
@@ -319,8 +320,9 @@ class TestCopyClaudeConfig:
         assert self._get_tar_content(container, ".claude/CLAUDE.md") == b"# Agent instructions"
         assert self._get_tar_content(container, "AGENTS.md") == b"# Agent instructions"
         assert b"/home/agent/AGENTS.md" in self._get_tar_content(container, ".aider.conf.yml")
-        # commands land in ~/.claude/commands/ for command-capable harnesses
+        # every command file lands in ~/.claude/commands/ for command-capable harnesses
         assert self._get_tar_content(container, ".claude/commands/self-review.md") == b"# self review"
+        assert self._get_tar_content(container, ".claude/commands/complexity-audit.md") == b"# complexity audit"
 
 
 class TestInjectGitCredentials:


### PR DESCRIPTION
## Summary

The **content** layer of the agent workframe (the mechanics landed in #64). Turns `docker/AGENTS.md` from a one-paragraph environment note into the forge agent's operating guide, and adds two commands that make its review discipline concrete and runnable.

## docker/AGENTS.md — the global prompt

Lean, principled, repo-agnostic (it's read by agents working on *any* repo forge spawns them on, not cc_forge):

- **Environment** — leans entirely on the `gh` shim; no Forgejo/routing plumbing exposed (the agent just uses `gh` and trusts it).
- **How to work** — understand first, smallest change that solves the task, leave unrelated code alone.
- **Review your own work** — a *firm, every-time* pre-PR step: run `/self-review`, then `/complexity-audit`, act, review again. Prose fallback for harnesses without commands.
- **Finish with a pull request** — open a PR with a *what + why* description (the producer convention that makes work promotable).
- **Conventions** — match style, one-line commits, no secrets.

## Commands (injected to ~/.claude/commands/)

- **`/self-review`** — producer self-review of your own diff. Leads with the highest-value check: *did you deliver the goal, with proof, or drift into tangential scaffolding?* — then Correct / Focused / Clear / Safe. (Distilled from the maintainer's `/review`, minus the GitHub-PR orchestration.)
- **`/complexity-audit`** — the maintainer's complexity-to-utility audit, re-scoped to *your change*: needless abstraction, should-combine/split, overguarding, overtesting, dead/speculative code.

## Wiring

`_inject_agent_instructions` now also ships `docker/commands/*.md` → `~/.claude/commands/`, so the `claude` agent (even on Ollama) can actually run the two steps. Commands sit alongside the existing `~/.claude/CLAUDE.md` / `~/AGENTS.md` / `~/.aider.conf.yml` injection.

## Deliberately out of scope

- **`/review`** (the PR back-and-forth) — reserved for the red-teaming/teams phase, not the single producing agent.
- **aider parity** — aider can't run `/`-commands, so the firm steps fall back to prose there; tracked, with the unverified instruction-load, in #66.

## Test plan

- [x] 143 unit tests pass — including command-file injection to `~/.claude/commands/`.
- [ ] Live: a real container session running `/self-review` + `/complexity-audit` before its PR (needs image rebuild on tesseract). aider's side tracked in #66.

Part of #55.
