### PR TITLE
Add eval task 07-fix-bug-from-traceback

### DIFF
--- a/scripts/eval/tasks/07-fix-bug-from-traceback/expect.md
+++ b/scripts/eval/tasks/07-fix-bug-from-traceback/expect.md
@@ -1,0 +1,109 @@
+# 07-fix-bug-from-traceback
+
+## Purpose
+
+Tests whether the agent can diagnose a runtime crash by reading a Python
+traceback that spans multiple files, trace the error to its root cause, and
+apply the correct fix — without being told which file contains the bug.
+
+This is a step up from `05-fix-failing-test`, which names the buggy file in
+the prompt. Here the agent must follow the traceback and data flow across
+four files to locate the root cause on its own.
+
+## Capability target
+
+- Running a command and reading its output (a multi-file traceback)
+- Parsing an `AttributeError` and understanding what `'NoneType'` implies
+- Distinguishing the crash site (symptom) from the root cause
+- Following data flow across module boundaries to find where the bad value originates
+- Editing the correct file to fix the underlying bug
+
+## Setup state
+
+Four Python files in a git repository:
+
+`/workspace/config.py`:
+```python
+def get_settings():
+    return {
+        "output_format": "csv",
+        "delimiter": None,       # BUG: should be ","
+        "include_header": True,
+    }
+```
+
+`/workspace/formatter.py`:
+```python
+def format_rows(headers, rows, delimiter):
+    lines = []
+    if headers:
+        lines.append(delimiter.join(headers))
+    for row in rows:
+        lines.append(delimiter.join(str(v) for v in row))
+    return "\n".join(lines)
+```
+
+`/workspace/app.py`:
+```python
+from config import get_settings
+from formatter import format_rows
+
+def generate_report(data):
+    settings = get_settings()
+    headers = list(data[0].keys())
+    rows = [list(d.values()) for d in data]
+    return format_rows(
+        headers if settings["include_header"] else None,
+        rows,
+        settings["delimiter"],
+    )
+```
+
+`/workspace/check.py`:
+```python
+from app import generate_report
+
+data = [
+    {"name": "Alice", "score": 95},
+    {"name": "Bob", "score": 87},
+]
+result = generate_report(data)
+expected = "name,score\nAlice,95\nBob,87"
+assert result == expected, f"Expected:\n{expected}\n\nGot:\n{result}"
+print("OK")
+```
+
+Running `python3 check.py` produces:
+
+```
+Traceback (most recent call last):
+  File "check.py", line 7, in <module>
+    result = generate_report(data)
+  File "app.py", line 8, in generate_report
+    return format_rows(
+  File "formatter.py", line 4, in format_rows
+    lines.append(delimiter.join(headers))
+AttributeError: 'NoneType' object has no attribute 'join'
+```
+
+The crash is in `formatter.py` but the root cause is in `config.py` — `delimiter` is `None` when it should be `","`.
+
+## Pass criteria
+
+1. `check.py` is unchanged from the initial commit (no sidestepping).
+2. `python3 check.py` exits 0 (output matches the expected CSV string).
+
+## Failure modes
+
+- **Does not run `check.py`**: No diagnostic signal; edits blindly or gives up.
+- **Edits `check.py`**: Sidestepping — rejected by `score.sh`.
+- **Patches `formatter.py` with a wrong default** (e.g., `delimiter or " "`): `check.py` still fails because the output won't match the expected comma-separated format.
+- **Cannot parse the traceback**: Edits the wrong file or wrong function entirely.
+- **Fixes only the crash without matching expected output**: e.g., sets delimiter to `"|"` — crash is gone but assertion fails.
+
+## Acceptable fixes
+
+- Setting `"delimiter"` to `","` in `config.py` (canonical fix).
+- Passing `","` directly in `app.py` instead of reading from config.
+- Adding `delimiter = delimiter or ","` in `formatter.py` (fixes the symptom with the correct default; still demonstrates traceback reading).
+- Any other change to non-test files that makes `check.py` pass.

--- a/scripts/eval/tasks/07-fix-bug-from-traceback/prompt.txt
+++ b/scripts/eval/tasks/07-fix-bug-from-traceback/prompt.txt
@@ -1,0 +1,1 @@
+Run `python3 check.py`. It crashes — fix the bug.

--- a/scripts/eval/tasks/07-fix-bug-from-traceback/score.sh
+++ b/scripts/eval/tasks/07-fix-bug-from-traceback/score.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Pass if check.py runs cleanly. Don't allow the model to "fix" by editing
+# the test file — score also checks that check.py is unchanged from setup.
+set -e
+
+[ -f check.py ] || { echo "check.py missing"; exit 2; }
+
+# Confirm the model didn't sidestep by editing check.py — compare against the
+# root (initial setup) commit so a later commit by the agent can't hide the edit.
+ROOT=$(git rev-list --max-parents=0 HEAD | head -1)
+if ! git diff --exit-code "$ROOT" -- check.py > /dev/null 2>&1; then
+    echo "check.py was modified — the fix should not touch the test file"
+    exit 3
+fi
+
+python3 check.py

--- a/scripts/eval/tasks/07-fix-bug-from-traceback/setup.sh
+++ b/scripts/eval/tasks/07-fix-bug-from-traceback/setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+git init -q
+git config user.email "eval@forge.local"
+git config user.name "Eval Setup"
+
+cat > config.py <<'PY'
+def get_settings():
+    return {
+        "output_format": "csv",
+        "delimiter": None,
+        "include_header": True,
+    }
+PY
+
+cat > formatter.py <<'PY'
+def format_rows(headers, rows, delimiter):
+    lines = []
+    if headers:
+        lines.append(delimiter.join(headers))
+    for row in rows:
+        lines.append(delimiter.join(str(v) for v in row))
+    return "\n".join(lines)
+PY
+
+cat > app.py <<'PY'
+from config import get_settings
+from formatter import format_rows
+
+def generate_report(data):
+    settings = get_settings()
+    headers = list(data[0].keys())
+    rows = [list(d.values()) for d in data]
+    return format_rows(
+        headers if settings["include_header"] else None,
+        rows,
+        settings["delimiter"],
+    )
+PY
+
+cat > check.py <<'PY'
+from app import generate_report
+
+data = [
+    {"name": "Alice", "score": 95},
+    {"name": "Bob", "score": 87},
+]
+result = generate_report(data)
+expected = "name,score\nAlice,95\nBob,87"
+assert result == expected, f"Expected:\n{expected}\n\nGot:\n{result}"
+print("OK")
+PY
+
+git add .
+git commit -qm "init"


### PR DESCRIPTION
## Summary

Adds a new eval task (`07-fix-bug-from-traceback`) to the screening suite that tests a capability the existing six tasks don't cover: **diagnosing a runtime crash by reading a multi-file Python traceback and tracing to the root cause without being told which file contains the bug.**

This is the next rung of difficulty above `05-fix-failing-test`, which names the buggy file in the prompt. Here the agent gets only `Run python3 check.py. It crashes — fix the bug.` and must figure out everything else from the traceback.

Closes #65

## What the task probes

The workspace contains four Python files forming a small pipeline:

- `config.py` — returns a settings dict; **bug: `"delimiter"` is `None` instead of `","`**
- `formatter.py` — joins rows with the delimiter; crashes with `AttributeError: 'NoneType' object has no attribute 'join'`
- `app.py` — glues config to formatter
- `check.py` — calls the pipeline and asserts expected CSV output

The traceback spans `check.py` → `app.py` → `formatter.py` (3 frames), but the root cause is in `config.py` — a file that doesn't appear in the traceback at all. The agent must:

1. Run `python3 check.py` to see the traceback
2. Parse the `AttributeError` and understand `'NoneType'` means a value is `None`
3. Follow the data flow: `delimiter` parameter comes from `settings["delimiter"]` in `app.py`, which comes from `get_settings()` in `config.py`
4. Fix the root cause (set `"delimiter"` to `","`)

## Canonical correct fix

In `config.py`, change `"delimiter": None` to `"delimiter": ","`.

## Local validation

```
# Setup the workspace
$ cd $(mktemp -d) && bash scripts/eval/tasks/07-fix-bug-from-traceback/setup.sh

# Verify initial state FAILS
$ bash scripts/eval/tasks/07-fix-bug-from-traceback/score.sh
AttributeError: 'NoneType' object has no attribute 'join'
# exit 1 ✓

# Apply canonical fix
$ sed -i 's/"delimiter": None/"delimiter": ","/' config.py

# Verify fixed state PASSES
$ bash scripts/eval/tasks/07-fix-bug-from-traceback/score.sh
OK
# exit 0 ✓

# Verify sidestepping is rejected
$ echo 'print("OK")' > check.py && git add check.py && git commit -qm "sidestep"
$ bash scripts/eval/tasks/07-fix-bug-from-traceback/score.sh
check.py was modified — the fix should not touch the test file
# exit 3 ✓

# Verify wrong delimiter default fails
$ sed -i 's/delimiter = delimiter or .*/delimiter = delimiter or " "/' formatter.py
$ bash scripts/eval/tasks/07-fix-bug-from-traceback/score.sh
AssertionError: Expected: name,score ...  Got: name score ...
# exit 1 ✓
```

## Test plan

- [x] `score.sh` passes when canonical fix is applied
- [x] `score.sh` fails when workspace is left in initial state
- [x] `score.sh` rejects edits to `check.py` (sidestepping)
- [x] `score.sh` fails with wrong delimiter default (e.g., space)
- [x] Existing tasks 01-06 unchanged