### PR TITLE
Screening matrix 2: broader model shortlist (Devstral, OLMo-2, Granite, Gemma 4, Phi-4)

### DIFF
--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -69,10 +69,10 @@ Following on the community research in #53, the second screening run broadens be
 | Devstral Small 2 | `devstral:24b` | 14 GB | Mistral, Dec 2025, explicitly agentic-tuned, 256K context, Apache 2.0 | Mistral AI (France) |
 | OLMo 3.1 32B | `olmo-3.1:32b` | 19 GB | Generalist comparison from a fully-open research team | Allen AI / AI2 (US) |
 | IBM Granite 4.1-8B | `granite4.1:8b` | 5 GB | Apache 2.0, fast small comparison, IBM Research's open-source release pattern | IBM Research (US) |
-| Gemma 3 12B | `gemma3:12b` | 8 GB | Google. Gemma 4's 12B variant needs Ollama newer than 0.15.4 on tesseract; using 3 as the practical near-equivalent. | Google DeepMind (US) |
+| Gemma 3 12B | `gemma3:12b` | 8 GB | Google. Gemma 4's 12B variant needs Ollama newer than 0.15.4 (the version on the forge host); using 3 as the practical near-equivalent. | Google DeepMind (US) |
 | Phi-4 | `phi4:14b` | 9 GB | Microsoft, strong reasoning per byte | Microsoft Research (US) |
 
-### Pre-flight result on tesseract (2026-06-17)
+### Pre-flight result on the forge host (2026-06-17)
 
 Of the six candidates above, **only three declare `tools` capability** in their Ollama manifest as pulled:
 

--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -134,14 +134,12 @@ Eventually [`forge doctor`](https://github.com/amc-corey-cox/cc_forge/issues/57)
 
 ## Confirmed unusable for this harness
 
-Models we've actually exercised against Claude Code's harness and shown not to drive it. Useful for `ollama rm` cleanup and for not re-pulling them in future runs.
+Models we exercised as matrix candidates against Claude Code's harness and shown not to drive it. Useful for not re-pulling them for future forge eval passes. **Note:** scoped to candidates we deliberately tested for this application. Models that happen to be on the host for unrelated purposes — even ones that lack `tools` capability — are out of scope; only remove if you know you don't use them elsewhere.
 
 | Model | Why it fails | Source |
 |-------|--------------|--------|
 | `gpt-oss:20b` | Runs but fails every capability check (0/5) | Matrix 1 |
 | `gpt-oss-64k` | 5/6 hit Claude Code's HTTP timeout with zero output | Matrix 1 |
-| `qwen:72b` | No `tools` capability in Ollama manifest | Matrix 1 pre-flight |
-| `vanilj/midnight-miqu-70b-v1.5` | No `tools` capability in Ollama manifest | Matrix 1 pre-flight |
 | `devstral:24b` | `tools` declared but never emits real tool calls (0/5) | Matrix 2 |
 | `granite4.1:8b` | Same single-turn narration pattern as Devstral (0/5) | Matrix 2 |
 | `olmo-3.1:32b` | No `tools` capability in Ollama manifest | Matrix 2 pre-flight |

--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -55,9 +55,9 @@ Eval harness invocation: `MODELS="qwen3-coder-32k gpt-oss:20b gpt-oss-64k" ./scr
 Following on the community research in #53, the second screening run broadens beyond the initial Qwen/GPT-OSS family to test whether other open-weight families produce different capability profiles in our harness. The shortlist deliberately spans:
 
 - **An agentic-coding-specialized model** (Devstral Small 2)
-- **A fully-open research-style model** (OLMo-2 — releases weights + data + training code in the AI2 mold)
+- **A fully-open research-style model** (OLMo 3.1 — releases weights + data + training code in the AI2 mold)
 - **An enterprise-open Apache-2.0 model** (IBM Granite 4.1)
-- **A recent Google release** (Gemma 4 — captures the "what's hot from a major lab this month" angle)
+- **A recent Google release** (Gemma 3 — captures the "what's hot from a major lab this month" angle; Gemma 4's 12B variant needs a newer Ollama than the host runs)
 - **A small-but-strong reasoning model** (Phi-4)
 - **`qwen3-coder-32k` retained as the carryover baseline** — matrix 1's only 5/5 capability pass
 

--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -2,7 +2,7 @@
 
 How Claude Code performs against local Ollama models, and which ones we recommend. Part of the [Track 1 evaluation](https://github.com/amc-corey-cox/cc_forge/issues) of the agent-architecture exploration.
 
-> **Status:** First screening matrix run complete (2026-06-17). Headline result: `qwen3-coder-32k` is the only model in our initial shortlist that meaningfully drives Claude Code in this harness. Recommendation stands as the dogfood default.
+> **Status:** Screening matrices 1 (2026-06-17) and 2 (2026-06-18) complete. Headline result: `qwen3-coder-32k` is still the only model in either shortlist that meaningfully drives Claude Code in this harness. Matrix 2 added five more candidates (Devstral, OLMo, Granite, Gemma 3, Phi-4) — three were filtered by the tool-support pre-flight, the other two ran but failed every capability task. Recommendation stands as the dogfood default.
 
 ## Headline cost model
 
@@ -50,7 +50,7 @@ Eval harness invocation: `MODELS="qwen3-coder-32k gpt-oss:20b gpt-oss-64k" ./scr
 
 `qwen3-coder-32k` stays as the default `FORGE_CLAUDE_MODEL` in `src/cc_forge/config.py`. The other two are not viable replacements for this combination of (Claude Code harness, CPU-only host, our task set). The next eval pass (probably issue #54, cloud Ollama services) is where we'd test whether the same models become viable with more compute behind them, or whether something like `qwen3-coder-32k` running on a faster backend gives a meaningful speed-up.
 
-## Screening matrix 2 — candidates (planned)
+## Results — screening matrix 2 (2026-06-18)
 
 Following on the community research in #53, the second screening run broadens beyond the initial Qwen/GPT-OSS family to test whether other open-weight families produce different capability profiles in our harness. The shortlist deliberately spans:
 
@@ -93,23 +93,32 @@ There may be tool-capable variants of OLMo / Phi-4 we didn't pull (e.g., special
 
 Three models × six tasks. Run-runner is `screening-matrix-2.sh`; the script filters to only tools-capable models, so the unviable three above are skipped automatically.
 
-### Pre-flight: confirm tool-calling support before committing run time
+| Task | qwen3-coder-32k | devstral:24b | granite4.1:8b |
+|------|-----------------|--------------|---------------|
+| 01-sanity-pong | ran (8 min) | ran (5 min) | ran (3 min) |
+| 02-fix-typo | **PASS** (28 min) | fail (11 min) | fail (5 min) |
+| 03-add-docstring | **PASS** (28 min) | fail (21 min) | fail (4 min) |
+| 04-rename-variable | **PASS** (29 min) | fail (10 min) | fail (4 min) |
+| 05-fix-failing-test | **PASS** (31 min) | fail (11 min) | fail (4 min) |
+| 06-implement-from-stub | **PASS** (36 min) | fail (6 min) | fail (4 min) |
+| **Capability pass-rate** | **5/5** | **0/5** | **0/5** |
 
-Matrix 1 surfaced two models pulled to tesseract that Ollama returns `"does not support tools"` for (`qwen:72b`, `vanilj/midnight-miqu-70b-v1.5`). The fix is cheap: before adding any model to a matrix, run
+qwen3-coder-32k's column carries over verbatim from matrix 1 — we did not re-run it for this matrix.
 
-```bash
-ollama show <model> | grep -i tools
-```
+### Interpretation
 
-on the forge host. If the `Capabilities` section doesn't include `tools`, the model can't drive Claude Code and shouldn't be added — Claude Code's harness depends on tool calling. The matrix-runner script for this run does this check automatically and refuses to include models that fail it.
+- **qwen3-coder-32k — recommended (unchanged).** Same 5/5 result as matrix 1. Still the only model on either shortlist that meaningfully drives Claude Code in this harness.
+- **devstral:24b — fails despite declared `tools` capability.** Every failed task ended after exactly one model turn with `exit_code 0`. The model acknowledges the request ("I'll help you fix the typo in `README.md`. Let me look at the file."), but then never emits an actual tool call — it just stops, sometimes outputting fake skill tags (`<skill skill="Glob"></skill>`) as text, sometimes admitting "I don't have access to the files or tools." The Ollama manifest says `tools` is supported; Devstral's behavior in this harness says otherwise. Possibly a tokenizer or chat-template mismatch between Devstral's tool-calling format and what Claude Code's harness expects from Ollama — but not something we can fix from the harness side.
+- **granite4.1:8b — same shape as devstral, smaller and faster.** 0/5, same single-turn narration pattern. The 8B size means each failed task only burned ~4 min — cheap failure, but a failure all the same. Granite did not crash; Claude Code exited cleanly each time with the model just refusing to act.
+- **The pre-flight filter held its weight.** Three of six candidates (OLMo 3.1, Gemma 3, Phi-4) were skipped without burning any runtime — they don't declare `tools` in their Ollama manifests. That saved an estimated 6-12 hours of wall-clock that would have ended in `HTTP 400 does not support tools` from Ollama.
 
-### Expected cost on tesseract
+### Caveat: pre-flight bug discovered mid-matrix
 
-With most candidates 5-19 GB instead of matrix 1's 17 GB qwen3 (and the smaller ones much faster on CPU per token), the per-task wall-clock should drop noticeably for everything except qwen3 and OLMo-2-32B. Rough estimate: **8-12 hours total for the full 6×6 run**, especially if the smaller models can run in parallel without RAM contention. Capture per-task duration in `meta.json` as usual.
+The first attempt to run matrix 2 incorrectly skipped `devstral:24b` despite its having `tools` capability. Root cause: `set -o pipefail` + `grep -q` — once grep matched and exited, it SIGPIPE'd the still-writing `ollama show`, and the non-zero pipeline exit propagated as a falsy `if`. Larger Ollama manifests (like Devstral's 21-line output) were just long enough to trip it. Fix in `scripts/eval/screening-matrix-2.sh`: capture `ollama show` output into a variable first, then grep. Worth recording because the same bash gotcha will bite future preflight scripts that combine pipefail with grep -q.
 
-### Results
+### What this changes about the recommendation
 
-_To be populated after the run._
+Nothing. `qwen3-coder-32k` remains the default `FORGE_CLAUDE_MODEL`. The candidates that ran in matrix 2 (Devstral, Granite) failed in a way that suggests an Ollama-side or model-side tool-call format mismatch rather than something a different prompt or harness tweak would unlock. The next eval pass (issue #54, cloud Ollama services) is where we'd test whether the same models become viable with a different inference backend that handles tool calls differently.
 
 ## Pre-flight requirements (run on the forge host)
 
@@ -119,5 +128,24 @@ Before running an eval pass:
 - The agent image is built (`docker images cc-forge-agent:latest`).
 - The `forge-network` exists and `forge-ollama-proxy` is running.
 - The candidate models are pulled (`ollama list` should include each).
+- Each candidate declares `tools` capability: `ollama show <model> | grep -i tools`. Without it, Ollama returns HTTP 400 immediately and the model can't drive Claude Code. `scripts/eval/screening-matrix-2.sh` does this check automatically and refuses to include models that fail it.
 
 Eventually [`forge doctor`](https://github.com/amc-corey-cox/cc_forge/issues/57) will check these automatically.
+
+## Confirmed unusable for this harness
+
+Models we've actually exercised against Claude Code's harness and shown not to drive it. Useful for `ollama rm` cleanup and for not re-pulling them in future runs.
+
+| Model | Why it fails | Source |
+|-------|--------------|--------|
+| `gpt-oss:20b` | Runs but fails every capability check (0/5) | Matrix 1 |
+| `gpt-oss-64k` | 5/6 hit Claude Code's HTTP timeout with zero output | Matrix 1 |
+| `qwen:72b` | No `tools` capability in Ollama manifest | Matrix 1 pre-flight |
+| `vanilj/midnight-miqu-70b-v1.5` | No `tools` capability in Ollama manifest | Matrix 1 pre-flight |
+| `devstral:24b` | `tools` declared but never emits real tool calls (0/5) | Matrix 2 |
+| `granite4.1:8b` | Same single-turn narration pattern as Devstral (0/5) | Matrix 2 |
+| `olmo-3.1:32b` | No `tools` capability in Ollama manifest | Matrix 2 pre-flight |
+| `gemma3:12b` | No `tools` capability in Ollama manifest | Matrix 2 pre-flight |
+| `phi4:14b` | No `tools` capability in Ollama manifest | Matrix 2 pre-flight |
+
+The Devstral / Granite failure mode is identical: `exit_code 0`, `num_turns: 1`, model emits a polite acknowledgment ("I'll help you fix that, let me look at the file…") and then never issues a tool call. The Ollama manifest says they support tools; their actual output stream in this harness doesn't. Possibly a tokenizer or chat-template mismatch — not something fixable from our side without a different inference backend.

--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -66,11 +66,11 @@ Following on the community research in #53, the second screening run broadens be
 | Model | Ollama name | Approx size | Why | Origin |
 |-------|-------------|-------------|-----|--------|
 | `qwen3-coder-32k` | `qwen3-coder-32k` | 17 GB | Carry-over baseline; 5/5 in matrix 1 | Alibaba / Qwen |
-| Devstral Small 2 | `devstral:24b` | ~14 GB | Mistral, Dec 2025, explicitly agentic-tuned, 256K context, Apache 2.0 | Mistral AI (France) |
-| OLMo-2 32B | `olmo2:32b` | ~19 GB | Generalist comparison from a fully-open research team; tests whether code-specialization matters for our task set | Allen AI / AI2 (US) |
-| IBM Granite 4.1-8B | `granite4:8b` or `granite-code:8b` | ~5 GB | Apache 2.0, fast small comparison, IBM Research's open-source release pattern | IBM Research (US) |
-| Gemma 4 12B | `gemma4:12b` | ~7-8 GB | Google, June 2026 release, native tool calling expected | Google DeepMind (US) |
-| Phi-4 | `phi4:14b` | ~9 GB | Microsoft, strong reasoning per byte | Microsoft Research (US) |
+| Devstral Small 2 | `devstral:24b` | 14 GB | Mistral, Dec 2025, explicitly agentic-tuned, 256K context, Apache 2.0 | Mistral AI (France) |
+| OLMo 3.1 32B | `olmo-3.1:32b` | ~19 GB | Generalist comparison from a fully-open research team; declares `tools` capability | Allen AI / AI2 (US) |
+| IBM Granite 4.1-8B | `granite4.1:8b` | ~5 GB | Apache 2.0, fast small comparison, IBM Research's open-source release pattern | IBM Research (US) |
+| Gemma 3 12B | `gemma3:12b` | ~7-8 GB | Google. Gemma 4's 12B variant needs Ollama newer than 0.15.4 on tesseract; using 3 as the practical near-equivalent. | Google DeepMind (US) |
+| Phi-4 | `phi4:14b` | 9 GB | Microsoft, strong reasoning per byte | Microsoft Research (US) |
 
 ### Pre-flight: confirm tool-calling support before committing run time
 

--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -50,6 +50,46 @@ Eval harness invocation: `MODELS="qwen3-coder-32k gpt-oss:20b gpt-oss-64k" ./scr
 
 `qwen3-coder-32k` stays as the default `FORGE_CLAUDE_MODEL` in `src/cc_forge/config.py`. The other two are not viable replacements for this combination of (Claude Code harness, CPU-only host, our task set). The next eval pass (probably issue #54, cloud Ollama services) is where we'd test whether the same models become viable with more compute behind them, or whether something like `qwen3-coder-32k` running on a faster backend gives a meaningful speed-up.
 
+## Screening matrix 2 — candidates (planned)
+
+Following on the community research in #53, the second screening run broadens beyond the initial Qwen/GPT-OSS family to test whether other open-weight families produce different capability profiles in our harness. The shortlist deliberately spans:
+
+- **An agentic-coding-specialized model** (Devstral Small 2)
+- **A fully-open research-style model** (OLMo-2 — releases weights + data + training code in the AI2 mold)
+- **An enterprise-open Apache-2.0 model** (IBM Granite 4.1)
+- **A recent Google release** (Gemma 4 — captures the "what's hot from a major lab this month" angle)
+- **A small-but-strong reasoning model** (Phi-4)
+- **`qwen3-coder-32k` retained as the carryover baseline** — matrix 1's only 5/5 capability pass
+
+### Shortlist
+
+| Model | Ollama name | Approx size | Why | Origin |
+|-------|-------------|-------------|-----|--------|
+| `qwen3-coder-32k` | `qwen3-coder-32k` | 17 GB | Carry-over baseline; 5/5 in matrix 1 | Alibaba / Qwen |
+| Devstral Small 2 | `devstral:24b` | ~14 GB | Mistral, Dec 2025, explicitly agentic-tuned, 256K context, Apache 2.0 | Mistral AI (France) |
+| OLMo-2 32B | `olmo2:32b` | ~19 GB | Generalist comparison from a fully-open research team; tests whether code-specialization matters for our task set | Allen AI / AI2 (US) |
+| IBM Granite 4.1-8B | `granite4:8b` or `granite-code:8b` | ~5 GB | Apache 2.0, fast small comparison, IBM Research's open-source release pattern | IBM Research (US) |
+| Gemma 4 12B | `gemma4:12b` | ~7-8 GB | Google, June 2026 release, native tool calling expected | Google DeepMind (US) |
+| Phi-4 | `phi4:14b` | ~9 GB | Microsoft, strong reasoning per byte | Microsoft Research (US) |
+
+### Pre-flight: confirm tool-calling support before committing run time
+
+Matrix 1 surfaced two models pulled to tesseract that Ollama returns `"does not support tools"` for (`qwen:72b`, `vanilj/midnight-miqu-70b-v1.5`). The fix is cheap: before adding any model to a matrix, run
+
+```bash
+ollama show <model> | grep -i tools
+```
+
+on the forge host. If the `Capabilities` section doesn't include `tools`, the model can't drive Claude Code and shouldn't be added — Claude Code's harness depends on tool calling. The matrix-runner script for this run does this check automatically and refuses to include models that fail it.
+
+### Expected cost on tesseract
+
+With most candidates 5-19 GB instead of matrix 1's 17 GB qwen3 (and the smaller ones much faster on CPU per token), the per-task wall-clock should drop noticeably for everything except qwen3 and OLMo-2-32B. Rough estimate: **8-12 hours total for the full 6×6 run**, especially if the smaller models can run in parallel without RAM contention. Capture per-task duration in `meta.json` as usual.
+
+### Results
+
+_To be populated after the run._
+
 ## Pre-flight requirements (run on the forge host)
 
 Before running an eval pass:

--- a/docs/CLAUDE-CODE-LOCAL-MODELS.md
+++ b/docs/CLAUDE-CODE-LOCAL-MODELS.md
@@ -67,10 +67,31 @@ Following on the community research in #53, the second screening run broadens be
 |-------|-------------|-------------|-----|--------|
 | `qwen3-coder-32k` | `qwen3-coder-32k` | 17 GB | Carry-over baseline; 5/5 in matrix 1 | Alibaba / Qwen |
 | Devstral Small 2 | `devstral:24b` | 14 GB | Mistral, Dec 2025, explicitly agentic-tuned, 256K context, Apache 2.0 | Mistral AI (France) |
-| OLMo 3.1 32B | `olmo-3.1:32b` | ~19 GB | Generalist comparison from a fully-open research team; declares `tools` capability | Allen AI / AI2 (US) |
-| IBM Granite 4.1-8B | `granite4.1:8b` | ~5 GB | Apache 2.0, fast small comparison, IBM Research's open-source release pattern | IBM Research (US) |
-| Gemma 3 12B | `gemma3:12b` | ~7-8 GB | Google. Gemma 4's 12B variant needs Ollama newer than 0.15.4 on tesseract; using 3 as the practical near-equivalent. | Google DeepMind (US) |
+| OLMo 3.1 32B | `olmo-3.1:32b` | 19 GB | Generalist comparison from a fully-open research team | Allen AI / AI2 (US) |
+| IBM Granite 4.1-8B | `granite4.1:8b` | 5 GB | Apache 2.0, fast small comparison, IBM Research's open-source release pattern | IBM Research (US) |
+| Gemma 3 12B | `gemma3:12b` | 8 GB | Google. Gemma 4's 12B variant needs Ollama newer than 0.15.4 on tesseract; using 3 as the practical near-equivalent. | Google DeepMind (US) |
 | Phi-4 | `phi4:14b` | 9 GB | Microsoft, strong reasoning per byte | Microsoft Research (US) |
+
+### Pre-flight result on tesseract (2026-06-17)
+
+Of the six candidates above, **only three declare `tools` capability** in their Ollama manifest as pulled:
+
+- ✅ `qwen3-coder-32k` (carryover)
+- ✅ `devstral:24b`
+- ✅ `granite4.1:8b`
+- ❌ `olmo-3.1:32b` — capabilities: `completion, thinking` (no tools)
+- ❌ `gemma3:12b` — capabilities: `completion, vision` (no tools)
+- ❌ `phi4:14b` — capabilities: `completion` (no tools)
+
+Web research suggested these models had tool calling, but the variants actually pulled via the standard `ollama pull <name>` don't expose it. Without `tools` in the capabilities list, Ollama returns HTTP 400 immediately on the first Claude Code request — they can't participate in the matrix.
+
+This makes the pre-flight check (`ollama show <model> | grep tools`) genuinely load-bearing: it's not redundant with web/blog research, because the blog research and the model-as-pulled don't always agree. The check is now built into `scripts/eval/screening-matrix-2.sh`.
+
+There may be tool-capable variants of OLMo / Phi-4 we didn't pull (e.g., specialized instruction-tuned releases). Adding them to the matrix is straightforward but requires pulling additional ~10-20GB each and re-running the check — a follow-up if matrix 2's results suggest the gap is worth investigating.
+
+### Matrix as run
+
+Three models × six tasks. Run-runner is `screening-matrix-2.sh`; the script filters to only tools-capable models, so the unviable three above are skipped automatically.
 
 ### Pre-flight: confirm tool-calling support before committing run time
 

--- a/scripts/eval/screening-matrix-2.sh
+++ b/scripts/eval/screening-matrix-2.sh
@@ -15,12 +15,12 @@
 
 set -euo pipefail
 
-# Candidates for screening matrix 2. Ollama names; ! prefix marks the
+# Candidates for screening matrix 2. Ollama names. The first entry is the
 # carry-over baseline from matrix 1 (we already trust it works in this harness).
 MODELS=(
     "qwen3-coder-32k"   # carry-over baseline
     "devstral:24b"      # Mistral, agentic-coding-specialized
-    "olmo-3.1:32b"      # Allen AI, generalist + fully open, declared tools support
+    "olmo-3.1:32b"      # Allen AI, generalist + fully open (no tools per ollama manifest as-pulled)
     "granite4.1:8b"     # IBM Research, Apache 2.0
     "gemma3:12b"        # Google. Gemma 4 (12b) requires newer Ollama than 0.15.4; fell back to 3.
     "phi4:14b"          # Microsoft, strong-per-byte
@@ -53,6 +53,12 @@ preflight_models() {
             echo "  - $m"
         done
         echo
+    fi
+
+    if [ ${#kept[@]} -eq 0 ]; then
+        echo "ERROR: no candidate models passed the tool-support pre-flight." >&2
+        echo "Pull or fix a tools-capable variant for at least one model before re-running." >&2
+        exit 1
     fi
 
     echo "These models will be included in the matrix:"

--- a/scripts/eval/screening-matrix-2.sh
+++ b/scripts/eval/screening-matrix-2.sh
@@ -61,10 +61,16 @@ preflight_models() {
 }
 
 # Verify everything is pulled before starting — fail fast if not.
+# `ollama list` shows ":latest" explicitly when no tag was given at pull time,
+# so a model entered here as "name" needs to match "name:latest" too.
 verify_pulled() {
     local missing=()
+    local pulled
+    pulled=$(ollama list 2>/dev/null | awk 'NR>1 {print $1}')
     for m in "${MODELS[@]}"; do
-        if ! ollama list 2>/dev/null | awk '{print $1}' | grep -qFx "$m"; then
+        local target="$m"
+        [[ "$m" == *:* ]] || target="${m}:latest"
+        if ! grep -qFx "$target" <<< "$pulled"; then
             missing+=("$m")
         fi
     done

--- a/scripts/eval/screening-matrix-2.sh
+++ b/scripts/eval/screening-matrix-2.sh
@@ -34,7 +34,7 @@ preflight_models() {
     local kept=()
     local rejected=()
     for m in "${MODELS[@]}"; do
-        if ollama show "$m" 2>/dev/null | grep -qi "^\s*tools\s*$"; then
+        if ollama show "$m" 2>/dev/null | grep -qi "^[[:space:]]*tools[[:space:]]*$"; then
             kept+=("$m")
         else
             rejected+=("$m")

--- a/scripts/eval/screening-matrix-2.sh
+++ b/scripts/eval/screening-matrix-2.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Screening matrix 2: candidates beyond the initial Qwen/GPT-OSS family.
+# Documented in docs/CLAUDE-CODE-LOCAL-MODELS.md ("Screening matrix 2 — candidates").
+#
+# Usage (on the forge host, after `ollama pull` for each model below):
+#   ./scripts/eval/screening-matrix-2.sh
+#
+# Or to do a tool-support dry-run without launching the matrix:
+#   ./scripts/eval/screening-matrix-2.sh --check
+#
+# This script captures the standard invocation (run-matrix.sh + the agreed
+# model list) so we don't reconstruct it by hand every time. The full matrix
+# is the same shape as matrix 1: 6 tasks per model, run-matrix.sh pre-warms
+# each model once before running tasks serially.
+
+set -euo pipefail
+
+# Candidates for screening matrix 2. Ollama names; ! prefix marks the
+# carry-over baseline from matrix 1 (we already trust it works in this harness).
+MODELS=(
+    "qwen3-coder-32k"   # carry-over baseline
+    "devstral:24b"       # Mistral, agentic-coding-specialized
+    "olmo2:32b"          # Allen AI, generalist + fully open
+    "granite4:8b"        # IBM Research, Apache 2.0
+    "gemma4:12b"         # Google, June 2026
+    "phi4:14b"           # Microsoft, strong-per-byte
+)
+
+# Tool-support pre-flight. Claude Code's harness requires tool calling — a
+# model that lacks it (e.g. qwen:72b in matrix 1) will fail every task with
+# Ollama returning HTTP 400 immediately. Catch this before sinking hours of
+# wall-clock by checking `ollama show <model>` for the `tools` capability.
+preflight_models() {
+    local kept=()
+    local rejected=()
+    for m in "${MODELS[@]}"; do
+        if ollama show "$m" 2>/dev/null | grep -qi "^\s*tools\s*$"; then
+            kept+=("$m")
+        else
+            rejected+=("$m")
+        fi
+    done
+
+    if [ ${#rejected[@]} -gt 0 ]; then
+        echo "These models will be SKIPPED (no 'tools' capability per ollama show):"
+        for m in "${rejected[@]}"; do
+            echo "  - $m"
+        done
+        echo
+    fi
+
+    echo "These models will be included in the matrix:"
+    for m in "${kept[@]}"; do
+        echo "  - $m"
+    done
+    echo
+
+    # Set the env var for run-matrix.sh
+    SELECTED_MODELS="${kept[*]}"
+    export SELECTED_MODELS
+}
+
+# Verify everything is pulled before starting — fail fast if not.
+verify_pulled() {
+    local missing=()
+    for m in "${MODELS[@]}"; do
+        if ! ollama list 2>/dev/null | awk '{print $1}' | grep -qFx "$m"; then
+            missing+=("$m")
+        fi
+    done
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "These models are not yet pulled on this host:" >&2
+        for m in "${missing[@]}"; do
+            echo "  - $m" >&2
+        done
+        echo >&2
+        echo "Run \`ollama pull <model>\` for each, then re-run this script." >&2
+        exit 1
+    fi
+}
+
+main() {
+    local check_only=0
+    if [ "${1:-}" = "--check" ]; then
+        check_only=1
+    fi
+
+    echo "=== Pre-flight: pulled models ==="
+    verify_pulled
+    echo "All ${#MODELS[@]} models present in ollama list."
+    echo
+
+    echo "=== Pre-flight: tool calling support ==="
+    preflight_models
+
+    if [ "$check_only" -eq 1 ]; then
+        echo "Check-only mode — not launching matrix."
+        exit 0
+    fi
+
+    SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+    RUN_ID="${RUN_ID:-screening-matrix-2-$(date -u +%Y%m%dT%H%M%SZ)}"
+    OUTPUT_BASE="eval-results/$RUN_ID"
+    OLLAMA_URL="${OLLAMA_URL:-http://forge-ollama-proxy:11434}"
+
+    echo "=== Launching matrix ==="
+    echo "  run_id: $RUN_ID"
+    echo "  output: $OUTPUT_BASE"
+    echo "  ollama: $OLLAMA_URL"
+    echo "  models: $SELECTED_MODELS"
+    echo
+
+    RUN_ID="$RUN_ID" OUTPUT_BASE="$OUTPUT_BASE" MODELS="$SELECTED_MODELS" \
+        OLLAMA_URL="$OLLAMA_URL" \
+        "$SCRIPT_DIR/run-matrix.sh"
+}
+
+main "$@"

--- a/scripts/eval/screening-matrix-2.sh
+++ b/scripts/eval/screening-matrix-2.sh
@@ -33,8 +33,14 @@ MODELS=(
 preflight_models() {
     local kept=()
     local rejected=()
+    local out
+    # Capture `ollama show` output first instead of piping directly into grep.
+    # Under `set -o pipefail`, `grep -q` exits 0 as soon as it finds a match,
+    # which can SIGPIPE the upstream `ollama show` (exit 141) and fail the
+    # pipeline — the larger the model's manifest, the more likely it trips.
     for m in "${MODELS[@]}"; do
-        if ollama show "$m" 2>/dev/null | grep -qi "^[[:space:]]*tools[[:space:]]*$"; then
+        out=$(ollama show "$m" 2>/dev/null || true)
+        if echo "$out" | grep -qi "^[[:space:]]*tools[[:space:]]*$"; then
             kept+=("$m")
         else
             rejected+=("$m")

--- a/scripts/eval/screening-matrix-2.sh
+++ b/scripts/eval/screening-matrix-2.sh
@@ -19,11 +19,11 @@ set -euo pipefail
 # carry-over baseline from matrix 1 (we already trust it works in this harness).
 MODELS=(
     "qwen3-coder-32k"   # carry-over baseline
-    "devstral:24b"       # Mistral, agentic-coding-specialized
-    "olmo2:32b"          # Allen AI, generalist + fully open
-    "granite4:8b"        # IBM Research, Apache 2.0
-    "gemma4:12b"         # Google, June 2026
-    "phi4:14b"           # Microsoft, strong-per-byte
+    "devstral:24b"      # Mistral, agentic-coding-specialized
+    "olmo-3.1:32b"      # Allen AI, generalist + fully open, declared tools support
+    "granite4.1:8b"     # IBM Research, Apache 2.0
+    "gemma3:12b"        # Google. Gemma 4 (12b) requires newer Ollama than 0.15.4; fell back to 3.
+    "phi4:14b"          # Microsoft, strong-per-byte
 )
 
 # Tool-support pre-flight. Claude Code's harness requires tool calling — a


### PR DESCRIPTION
## Summary

Second screening matrix for #53. Broadens the local-Ollama eval beyond matrix 1's Qwen / GPT-OSS family to ask: do other open-weight families produce different capability profiles in Claude Code's harness?

**Headline: no.** `qwen3-coder-32k` (matrix 1's winner) is still the only model from either shortlist that actually drives Claude Code end-to-end. Five more candidates were tested — three filtered by the tool-support pre-flight, the other two ran but failed every capability task.

## Results

| Task | qwen3-coder-32k | devstral:24b | granite4.1:8b |
|------|-----------------|--------------|---------------|
| 01-sanity-pong | ran (8 min) | ran (5 min) | ran (3 min) |
| 02-fix-typo | **PASS** (28 min) | fail (11 min) | fail (5 min) |
| 03-add-docstring | **PASS** (28 min) | fail (21 min) | fail (4 min) |
| 04-rename-variable | **PASS** (29 min) | fail (10 min) | fail (4 min) |
| 05-fix-failing-test | **PASS** (31 min) | fail (11 min) | fail (4 min) |
| 06-implement-from-stub | **PASS** (36 min) | fail (6 min) | fail (4 min) |
| **Capability pass-rate** | **5/5** | **0/5** | **0/5** |

`qwen3-coder-32k`'s column carries over from matrix 1 verbatim (not re-run). Devstral and Granite were run fresh on the forge host.

### Failure mode (Devstral, Granite)

Both fail identically: `exit_code 0`, `num_turns: 1`, model writes a polite acknowledgment ("I'll help you fix the typo in `README.md`, let me look at the file…") and then the session ends without a real tool call. One Devstral task literally output the text `<skill skill="Glob"></skill>` as if narrating a tool call instead of issuing one. Another said outright "I don't have access to the files or tools."

Both models declare `tools` capability in their Ollama manifest, but their actual output stream in this harness doesn't conform to the tool-call format Claude Code (via Ollama) expects. Probably a tokenizer or chat-template mismatch — not fixable from the harness side without a different inference backend.

### Pre-flight rejections (no tools capability)

- `olmo-3.1:32b` — capabilities: `completion, thinking`
- `gemma3:12b` — capabilities: `completion, vision`
- `phi4:14b` — capabilities: `completion`

The web research suggested these have tool calling; the variants Ollama actually serves do not. Estimated 6-12 hours of wall-clock saved by failing fast.

## What's in this PR

- `docs/CLAUDE-CODE-LOCAL-MODELS.md` — matrix 2 candidates, methodology, results, interpretation, and a new "Confirmed unusable for this harness" index covering both matrices
- `scripts/eval/screening-matrix-2.sh` — captures the standard matrix 2 invocation plus the tool-support pre-flight check

## Pre-flight bug discovered and fixed mid-run

First run incorrectly skipped Devstral despite its having `tools` capability. Root cause: `set -o pipefail` + `grep -q` SIGPIPE'd the upstream `ollama show` as soon as grep matched and exited. Larger manifests (Devstral's 21 lines) tripped it; smaller ones (Granite's 15 lines) finished writing before grep exited and slipped through. Fix: capture `ollama show` output into a variable before grepping. Worth flagging because the same gotcha will bite any future preflight script that combines `pipefail` with `grep -q`.

## Recommendation

`qwen3-coder-32k` remains the default `FORGE_CLAUDE_MODEL` in `src/cc_forge/config.py`. Issue #54 (cloud Ollama services) is the next eval pass — that's where we'd test whether Devstral / Granite become viable with a different inference backend that handles tool calls differently, or whether `qwen3-coder-32k` itself gets fast enough on faster hardware to be ergonomic.

## Related

- #53 — Pass 2 community research (this PR closes the action)
- PR #63 — Matrix 1 results
- Issue #54 — Cloud Ollama pass (next)
