### PR TITLE
Tell forge agents not to add AI attribution to PRs or commits

### DIFF
--- a/docker/AGENTS.md
+++ b/docker/AGENTS.md
@@ -47,3 +47,4 @@ Write it for the human who will read it.
 - Match the existing style of the code you're editing.
 - Keep commit messages to one concise line.
 - Never commit secrets or credentials.
+- Don't add AI or "Generated with …" attribution to PRs or commit messages.


### PR DESCRIPTION
## Summary

- Adds a convention line to `docker/AGENTS.md` instructing forge agents not to add AI or "Generated with …" attribution to PR descriptions or commit messages.
- `docker/CLAUDE.md` is a symlink to `AGENTS.md`, so all harnesses pick up the instruction automatically.

## Why

Surfaced during dogfood validation (#65/#69): the forge agent added `🤖 Generated with Claude Code` to its PR body, violating the project's standing convention. The container global prompt (#67) never told agents to omit it, so they default to adding it. This one-line addition closes that gap.

Fixes #71