### PR TITLE
Add v0.1.0 usage docs: session workflow + promote

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ forge stop --all
 
 What happens when you type `forge`:
 
-1. Forgejo and Ollama proxies start automatically if they aren't running.
+1. The forge infrastructure (Forgejo + Ollama proxies) starts if Forgejo isn't already up.
 2. Your repo is pushed to the local Forgejo instance.
 3. An isolated container clones from Forgejo and drops you into an interactive
    Claude Code session.
@@ -89,12 +89,13 @@ forge promote <forgejo-pr-number>
 `forge promote` fetches the agent's branch from Forgejo, pushes it to your
 GitHub remote, and opens a GitHub PR with the same title and description.
 
-**Why promote runs on the workstation:** The agent container can talk to Forgejo
+**Why promote runs on your machine:** The agent container can talk to Forgejo
 but not to GitHub. Promotion is the deliberate step where reviewed work crosses
-that boundary — your `gh` credentials stay on your machine, never inside the
-container. You'll need `gh` authenticated and `FORGE_GITHUB_REPO` (or
-`FORGE_GITHUB_OWNER`) in your config — see
-[docs/FORGE-USAGE.md](docs/FORGE-USAGE.md) for details.
+that boundary — your `gh` credentials stay with you, never inside the container.
+You'll need `gh` authenticated. On a single machine, also set `FORGE_GITHUB_REPO`
+(or `FORGE_GITHUB_OWNER`) in your config; if forge runs on a separate server, you
+promote from your workstation and it infers the repo from `origin`. See
+[docs/FORGE-USAGE.md](docs/FORGE-USAGE.md) for both setups.
 
 ### The Full Loop
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ uv sync
    EOF
    ```
 
-### Usage
+### Run a Session
 
 ```bash
-# In any git repo:
+# In any git repo — launches Claude Code with local Ollama:
 forge
+
+# Or use your Claude API key instead of local models:
+forge run --claude
 
 # Use Aider instead of Claude Code:
 forge run --agent aider
@@ -62,16 +65,55 @@ forge status
 forge stop --all
 ```
 
-### Review Workflow
+What happens when you type `forge`:
 
-1. `forge` syncs your repo to local Forgejo and launches an agent container
-2. The agent works, commits, and pushes to Forgejo
-3. Review changes in Forgejo web UI (`http://localhost:3000`)
-4. Pull approved work: `git pull forgejo <branch>`
-5. Push to GitHub as usual
+1. Forgejo and Ollama proxies start automatically if they aren't running.
+2. Your repo is pushed to the local Forgejo instance.
+3. An isolated container clones from Forgejo and drops you into an interactive
+   Claude Code session.
+4. The agent works, commits, and opens a PR — all inside Forgejo.
+
+When the session ends you're back in your original shell. The agent's work lives
+in Forgejo until you're ready to bring it over.
+
+### Review and Promote
+
+The agent's PR lands in Forgejo (`http://localhost:3000`). Read the diff there,
+then promote it to GitHub when you're satisfied:
+
+```bash
+# From the same repo, on your workstation:
+forge promote <forgejo-pr-number>
+```
+
+`forge promote` fetches the agent's branch from Forgejo, pushes it to your
+GitHub remote, and opens a GitHub PR with the same title and description.
+
+**Why promote runs on the workstation:** The agent container can talk to Forgejo
+but not to GitHub. Promotion is the deliberate step where reviewed work crosses
+that boundary — your `gh` credentials stay on your machine, never inside the
+container. You'll need `gh` authenticated and `FORGE_GITHUB_REPO` (or
+`FORGE_GITHUB_OWNER`) in your config — see
+[docs/FORGE-USAGE.md](docs/FORGE-USAGE.md) for details.
+
+### The Full Loop
+
+A typical issue-to-PR cycle looks like this:
+
+```
+forge run --claude          # start a session
+  ↳ agent works on the task
+  ↳ agent runs /self-review and /complexity-audit
+  ↳ agent opens a Forgejo PR
+                            # session ends, you're back in your shell
+forge promote 1             # push the PR to GitHub
+```
+
+See [docs/FORGE-USAGE.md](docs/FORGE-USAGE.md) for the detailed walkthrough.
 
 ## Documentation
 
+- [docs/FORGE-USAGE.md](docs/FORGE-USAGE.md) — Running a session end-to-end
 - [DESIGN.md](DESIGN.md) — Architecture and safety model
 - [ROADMAP.md](ROADMAP.md) — Implementation phases
 - [AGENTS.md](AGENTS.md) — Instructions for AI agents working in this repo
@@ -79,7 +121,8 @@ forge stop --all
 
 ## Status
 
-Phase 1: Foundation — `forge` CLI with end-to-end session flow.
+Phase 1 — the human-driven single-issue loop. An agent takes a task, works in
+isolation, self-reviews, and hands back a promotable PR.
 
 See [ROADMAP.md](ROADMAP.md) for the full plan.
 

--- a/docs/FORGE-USAGE.md
+++ b/docs/FORGE-USAGE.md
@@ -1,0 +1,195 @@
+# Running a Forge Session
+
+This guide walks through the Phase-1 loop: give an agent a task, let it work in
+isolation, review what it did, and promote the result to GitHub.
+
+---
+
+## Prerequisites
+
+**On the server (where forge and Docker run):**
+
+- Docker and Docker Compose
+- Ollama running locally (see [LOCAL-OLLAMA-SETUP.md](LOCAL-OLLAMA-SETUP.md))
+- Python 3.11+ and [uv](https://docs.astral.sh/uv/)
+- `forge` installed (`uv sync` in the cc_forge checkout)
+- A Forgejo admin account and API token (see the README's First-Time Setup)
+- `~/.config/forge/config.env` with at least `FORGE_FORGEJO_TOKEN`
+
+**On the workstation (where you promote to GitHub):**
+
+- The `gh` CLI, authenticated (`gh auth login`)
+- A clone of the same repository with an `origin` remote pointing at GitHub
+
+If the server and workstation are the same machine, both sets of prerequisites
+apply there.
+
+---
+
+## 1. Start a Session
+
+Navigate to any git repository and run:
+
+```bash
+forge
+```
+
+This starts Claude Code backed by local Ollama models. Behind the scenes forge:
+
+1. Starts Forgejo and the Ollama proxy containers if they aren't already running.
+2. Creates the repository on Forgejo if it doesn't exist yet.
+3. Pushes your current branch to Forgejo.
+4. Launches an agent container that clones from Forgejo (no host mount).
+5. Drops you into an interactive Claude Code session inside the container.
+
+### Using the Claude API instead of local models
+
+If you have an Anthropic API key and want to use it instead of Ollama:
+
+```bash
+forge run --claude
+```
+
+Set `FORGE_CLAUDE_API_KEY` in your `config.env` (or export `ANTHROPIC_API_KEY`
+— forge checks both). The `--claude` flag tells forge to route requests to the
+Anthropic API rather than the local Ollama proxy.
+
+### Using Aider
+
+```bash
+forge run --agent aider
+```
+
+This launches Aider instead of Claude Code. Aider connects to the same Ollama
+instance.
+
+---
+
+## 2. The Agent Workflow
+
+Once inside the session the agent has a clone of your repo and can read, edit,
+commit, and push. It also has access to `gh` (a shim that routes to Forgejo for
+writes and to GitHub for reads).
+
+A well-behaved session follows this sequence:
+
+1. **Understand the task.** Read the relevant code and the issue until the goal
+   is clear.
+2. **Make the change.** Write the smallest diff that fully solves the task.
+3. **Self-review.** Run `/self-review` — this checks the change against the
+   task goals for correctness, focus, and clarity.
+4. **Complexity audit.** Run `/complexity-audit` — this checks for unnecessary
+   abstraction, over-engineering, or defensive code that doesn't earn its keep.
+5. **Open a PR.** The agent opens a pull request on Forgejo via `gh pr create`.
+
+The `/self-review` and `/complexity-audit` commands are Claude Code slash
+commands injected into the container. They're the single-agent seed of forge's
+planned multi-agent review teams.
+
+---
+
+## 3. Review the Work
+
+When the session ends you're back in your shell. The agent's commits and PR live
+in Forgejo.
+
+Open the Forgejo web UI at `http://localhost:3000` (or wherever your Forgejo
+instance is running) to:
+
+- Read the PR description and diff.
+- Check the commit history.
+- Leave comments if you plan to iterate.
+
+If the work isn't right, start another session — the agent will pick up from the
+current state of the Forgejo branch.
+
+If you just want the changes locally without opening a GitHub PR, you can pull
+the agent's branch directly:
+
+```bash
+git fetch forgejo
+git merge forgejo/<branch-name>
+```
+
+---
+
+## 4. Promote to GitHub
+
+Once you're satisfied with the PR, promote it:
+
+```bash
+forge promote <pr-number>
+```
+
+Where `<pr-number>` is the Forgejo PR number (visible in the Forgejo UI).
+
+This command:
+
+1. Fetches the agent's branch from the `forgejo` remote.
+2. Creates a local branch tracking it.
+3. Pushes the branch to your GitHub remote (`origin` by default).
+4. Opens a GitHub PR with the same title and description.
+5. Prints the GitHub PR URL.
+
+### Why promote exists
+
+The agent container can talk to Forgejo but has no GitHub credentials. Promotion
+is the deliberate boundary crossing: reviewed work moves from the local safety
+zone to the public repository, using your credentials, on your machine.
+
+### Options
+
+```bash
+# Push to a different remote:
+forge promote 1 --remote upstream
+
+# Run from a different directory:
+forge promote 1 --repo /path/to/repo
+```
+
+### Configuration for promote
+
+`forge promote` needs to know where to push on GitHub. Set one of these in
+`~/.config/forge/config.env`:
+
+- `FORGE_GITHUB_REPO` — explicit `owner/repo` (e.g. `amc-corey-cox/cc_forge`).
+- `FORGE_GITHUB_OWNER` — just the owner; the repo name is derived from the
+  local directory.
+
+One of these is required. Promote will warn if the resolved repo doesn't match
+your `origin` remote URL, but it doesn't fall back to parsing the remote.
+
+For authentication, promote uses ambient `gh auth` by default. If you prefer
+token-based auth, set `FORGE_GITHUB_TOKEN` in `~/.config/forge/config.env`.
+
+You can also inspect a Forgejo PR's metadata without promoting it:
+
+```bash
+forge pr-show <pr-number>
+```
+
+This prints the head branch, base branch, title, and body as JSON.
+
+---
+
+## Configuration Reference
+
+All settings live in `~/.config/forge/config.env` (or a `.env` file in the
+working directory, or environment variables). Environment variables take
+precedence.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FORGE_FORGEJO_TOKEN` | *(required)* | Forgejo API token |
+| `FORGE_FORGEJO_URL` | `http://localhost:3000` | Forgejo instance URL |
+| `FORGE_CLAUDE_API_KEY` | *(empty)* | Anthropic API key for `--claude` mode |
+| `FORGE_CLAUDE_MODEL` | `qwen3-coder-32k` | Model name for Claude Code (Ollama mode) |
+| `FORGE_GITHUB_TOKEN` | *(empty)* | GitHub token for promote (optional if `gh` is authed) |
+| `FORGE_GITHUB_REPO` | *(empty)* | GitHub `owner/repo` for promote (required unless `FORGE_GITHUB_OWNER` is set) |
+| `FORGE_GITHUB_OWNER` | *(empty)* | GitHub owner for promote (repo name derived from local directory) |
+| `FORGE_AGENT_IMAGE` | `cc-forge-agent:latest` | Docker image for agent containers |
+| `FORGE_AGENT_MEM_LIMIT` | `4g` | Memory limit per agent container |
+
+---
+
+*Last updated: 2026-06-17*

--- a/docs/FORGE-USAGE.md
+++ b/docs/FORGE-USAGE.md
@@ -1,7 +1,8 @@
 # Running a Forge Session
 
-This guide walks through the Phase-1 loop: give an agent a task, let it work in
-isolation, review what it did, and promote the result to GitHub.
+This guide walks the Phase-1 loop end to end: hand an agent a task, let it work
+in an isolated container, review what it did in Forgejo, and promote the result
+to GitHub.
 
 ---
 
@@ -16,180 +17,160 @@ isolation, review what it did, and promote the result to GitHub.
 - A Forgejo admin account and API token (see the README's First-Time Setup)
 - `~/.config/forge/config.env` with at least `FORGE_FORGEJO_TOKEN`
 
-**On the workstation (where you promote to GitHub):**
+**On the workstation (only if you run forge on a separate server):**
 
+- The `forge` wrapper from `scripts/remote-forge/` installed as your `forge`
+- SSH access to the server
 - The `gh` CLI, authenticated (`gh auth login`)
-- A clone of the same repository with an `origin` remote pointing at GitHub
+- A clone of the same repository whose `origin` points at GitHub
 
-If the server and workstation are the same machine, both sets of prerequisites
-apply there.
+If forge and you live on the same machine, ignore the workstation column — the
+server prerequisites are all you need.
 
 ---
 
 ## 1. Start a Session
 
-Navigate to any git repository and run:
+From any git repository, run:
 
 ```bash
 forge
 ```
 
-This starts Claude Code backed by local Ollama models. Behind the scenes forge:
+This launches Claude Code backed by local Ollama models. Behind the scenes forge:
 
-1. Starts Forgejo and the Ollama proxy containers if they aren't already running.
+1. Starts the infrastructure (Forgejo + the Ollama proxies) if Forgejo isn't
+   already running.
 2. Creates the repository on Forgejo if it doesn't exist yet.
 3. Pushes your current branch to Forgejo.
-4. Launches an agent container that clones from Forgejo (no host mount).
+4. Launches an agent container that clones from Forgejo — no host mount.
 5. Drops you into an interactive Claude Code session inside the container.
 
-### Using the Claude API instead of local models
-
-If you have an Anthropic API key and want to use it instead of Ollama:
+### Use the Claude API instead of local models
 
 ```bash
 forge run --claude
 ```
 
-Set `FORGE_CLAUDE_API_KEY` in your `config.env` (or export `ANTHROPIC_API_KEY`
-— forge checks both). The `--claude` flag tells forge to route requests to the
-Anthropic API rather than the local Ollama proxy.
+Set `FORGE_CLAUDE_API_KEY` in `config.env` (forge also honors `ANTHROPIC_API_KEY`).
+The `--claude` flag routes the agent to the Anthropic API instead of the local
+Ollama proxy.
 
-### Using Aider
+### Use Aider
 
 ```bash
 forge run --agent aider
 ```
 
-This launches Aider instead of Claude Code. Aider connects to the same Ollama
-instance.
+Launches Aider against the same Ollama instance instead of Claude Code.
 
 ---
 
 ## 2. The Agent Workflow
 
-Once inside the session the agent has a clone of your repo and can read, edit,
-commit, and push. It also has access to `gh` (a shim that routes to Forgejo for
-writes and to GitHub for reads).
+Inside the session the agent has a clone of your repo and can read, edit, commit,
+and push. It also has `gh` — a shim that routes pull-request and repo operations
+to Forgejo, and issue reads to GitHub. (GitHub reads need `FORGE_GITHUB_TOKEN`
+configured; without it, GitHub-bound commands fail.)
 
-A well-behaved session follows this sequence:
+A well-behaved session follows this shape:
 
-1. **Understand the task.** Read the relevant code and the issue until the goal
-   is clear.
-2. **Make the change.** Write the smallest diff that fully solves the task.
-3. **Self-review.** Run `/self-review` — this checks the change against the
-   task goals for correctness, focus, and clarity.
-4. **Complexity audit.** Run `/complexity-audit` — this checks for unnecessary
-   abstraction, over-engineering, or defensive code that doesn't earn its keep.
-5. **Open a PR.** The agent opens a pull request on Forgejo via `gh pr create`.
+1. **Understand the task** — read the relevant code until the goal is clear.
+2. **Make the change** — the smallest diff that fully solves it.
+3. **`/self-review`** — check the diff for correctness, focus, and clarity.
+4. **`/complexity-audit`** — check for abstraction or defensive code that isn't
+   earning its keep.
+5. **Open a PR** — `gh pr create` on Forgejo.
 
-The `/self-review` and `/complexity-audit` commands are Claude Code slash
-commands injected into the container. They're the single-agent seed of forge's
-planned multi-agent review teams.
+`/self-review` and `/complexity-audit` are Claude Code slash commands injected
+into the container. They're the single-agent seed of forge's planned review teams.
 
 ---
 
 ## 3. Review the Work
 
-When the session ends you're back in your shell. The agent's commits and PR live
-in Forgejo.
+When the session ends you're back in your shell; the agent's commits and PR live
+in Forgejo. Open the Forgejo web UI (`http://localhost:3000`, or wherever your
+instance runs) to read the PR description, the diff, and the commit history.
 
-Open the Forgejo web UI at `http://localhost:3000` (or wherever your Forgejo
-instance is running) to:
-
-- Read the PR description and diff.
-- Check the commit history.
-- Leave comments if you plan to iterate.
-
-If the work isn't right, start another session — the agent will pick up from the
-current state of the Forgejo branch.
-
-If you just want the changes locally without opening a GitHub PR, you can pull
-the agent's branch directly:
+To iterate, start another session — but note that `forge` pushes your *current
+local branch* to Forgejo at startup. If the agent's branch has moved ahead, pull
+it into your local checkout first, or that push will be rejected:
 
 ```bash
 git fetch forgejo
 git merge forgejo/<branch-name>
 ```
 
+That same fetch-and-merge is also how you take the agent's work locally if you
+don't intend to open a GitHub PR at all.
+
 ---
 
 ## 4. Promote to GitHub
 
-Once you're satisfied with the PR, promote it:
+When you're satisfied with the Forgejo PR, promote it:
 
 ```bash
 forge promote <pr-number>
 ```
 
-Where `<pr-number>` is the Forgejo PR number (visible in the Forgejo UI).
+`<pr-number>` is the Forgejo PR number (shown in the Forgejo UI). Promote fetches
+the agent's branch, creates a local branch from it, pushes that to your GitHub
+remote (`origin` by default), opens a GitHub PR with the same title and body, and
+prints the URL.
 
-This command:
+**Promotion runs where your GitHub credentials are — your machine, never the
+container.** The agent container can reach Forgejo but has no GitHub access, so
+crossing to GitHub is a deliberate, human-authorized step. How it plays out
+depends on your setup:
 
-1. Fetches the agent's branch from the `forgejo` remote.
-2. Creates a local branch tracking it.
-3. Pushes the branch to your GitHub remote (`origin` by default).
-4. Opens a GitHub PR with the same title and description.
-5. Prints the GitHub PR URL.
+- **Single machine** — forge, Forgejo, and you on one host. `forge promote` reads
+  the local Forgejo directly and pushes to GitHub. It needs `gh` authenticated
+  (or `FORGE_GITHUB_TOKEN`), plus the GitHub target set via `FORGE_GITHUB_REPO`
+  (`owner/repo`) or `FORGE_GITHUB_OWNER` in `config.env`.
 
-### Why promote exists
-
-The agent container can talk to Forgejo but has no GitHub credentials. Promotion
-is the deliberate boundary crossing: reviewed work moves from the local safety
-zone to the public repository, using your credentials, on your machine.
+- **Separate workstation + server** — run `forge promote` on your **workstation**
+  (the `scripts/remote-forge/` wrapper). It SSHes to the server for the PR's
+  metadata, then does the push and GitHub PR locally with your `gh` auth,
+  **inferring the repo from your `origin` remote — so no `FORGE_GITHUB_*` config
+  is needed on the workstation**. You need the wrapper installed and SSH to the
+  server.
 
 ### Options
 
 ```bash
-# Push to a different remote:
-forge promote 1 --remote upstream
-
-# Run from a different directory:
+forge promote 1 --remote upstream    # push to a remote other than origin
 forge promote 1 --repo /path/to/repo
 ```
 
-### Configuration for promote
-
-`forge promote` needs to know where to push on GitHub. Set one of these in
-`~/.config/forge/config.env`:
-
-- `FORGE_GITHUB_REPO` — explicit `owner/repo` (e.g. `amc-corey-cox/cc_forge`).
-- `FORGE_GITHUB_OWNER` — just the owner; the repo name is derived from the
-  local directory.
-
-One of these is required. Promote will warn if the resolved repo doesn't match
-your `origin` remote URL, but it doesn't fall back to parsing the remote.
-
-For authentication, promote uses ambient `gh auth` by default. If you prefer
-token-based auth, set `FORGE_GITHUB_TOKEN` in `~/.config/forge/config.env`.
-
-You can also inspect a Forgejo PR's metadata without promoting it:
+### Inspect a PR without promoting
 
 ```bash
 forge pr-show <pr-number>
 ```
 
-This prints the head branch, base branch, title, and body as JSON.
+Prints the head branch, base branch, title, and body as JSON. (It's also the call
+the workstation wrapper makes under the hood to fetch metadata from the server.)
 
 ---
 
 ## Configuration Reference
 
-All settings live in `~/.config/forge/config.env` (or a `.env` file in the
-working directory, or environment variables). Environment variables take
-precedence.
+Settings are read from `~/.config/forge/config.env`, a `.env` file in the working
+directory, or environment variables (which take precedence). The common ones:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `FORGE_FORGEJO_TOKEN` | *(required)* | Forgejo API token |
 | `FORGE_FORGEJO_URL` | `http://localhost:3000` | Forgejo instance URL |
 | `FORGE_CLAUDE_API_KEY` | *(empty)* | Anthropic API key for `--claude` mode |
-| `FORGE_CLAUDE_MODEL` | `qwen3-coder-32k` | Model name for Claude Code (Ollama mode) |
-| `FORGE_GITHUB_TOKEN` | *(empty)* | GitHub token for promote (optional if `gh` is authed) |
-| `FORGE_GITHUB_REPO` | *(empty)* | GitHub `owner/repo` for promote (required unless `FORGE_GITHUB_OWNER` is set) |
-| `FORGE_GITHUB_OWNER` | *(empty)* | GitHub owner for promote (repo name derived from local directory) |
+| `FORGE_CLAUDE_MODEL` | `qwen3-coder-32k` | Model for Claude Code in Ollama mode |
+| `FORGE_GITHUB_TOKEN` | *(empty)* | GitHub token — for the agent's GitHub reads, and for promote when `gh` isn't authed |
+| `FORGE_GITHUB_REPO` | *(empty)* | GitHub `owner/repo` for single-machine promote (or set `FORGE_GITHUB_OWNER`) |
+| `FORGE_GITHUB_OWNER` | *(empty)* | GitHub owner; repo name derived from the local directory |
 | `FORGE_AGENT_IMAGE` | `cc-forge-agent:latest` | Docker image for agent containers |
 | `FORGE_AGENT_MEM_LIMIT` | `4g` | Memory limit per agent container |
 
----
-
-*Last updated: 2026-06-17*
+This is the set you'll usually touch, not every knob — see `config.py` for the
+full list.


### PR DESCRIPTION
## Summary

Adds front-door usage documentation for the Phase-1 loop, covering the full issue-to-PR cycle:

- **README.md** — Expanded "Run a Session" section with `forge run --claude`, "Review and Promote" section explaining `forge promote` and the host-boundary split, and "The Full Loop" showing the end-to-end flow (self-review, complexity-audit, Forgejo PR, promote to GitHub).
- **docs/FORGE-USAGE.md** — Step-by-step walkthrough: prerequisites (server vs. workstation), starting a session, the agent workflow, reviewing in Forgejo, promoting to GitHub, and a configuration reference table.

All config defaults and promote resolution logic verified against `src/cc_forge/config.py` and `src/cc_forge/promote.py`.

## Note for reviewer

Issue #76 says "hand-authored, not agent-authored. Voice matters." This draft was agent-authored at the user's request. Review the voice and adjust before merging.

Closes #76