### PR TITLE
Fix wrapper passing a phantom '' arg on no-arg subcommands (bare forge run)

### DIFF
--- a/scripts/remote-forge/workstation-wrapper
+++ b/scripts/remote-forge/workstation-wrapper
@@ -14,6 +14,11 @@
 
 set -e
 
+# Quote args for the remote shell; emits nothing when there are none. A bare
+# `printf '%q '` with no args emits a stray '' that server-side Click rejects
+# ("Got unexpected extra argument ()"), e.g. on a plain `forge run`.
+q() { [ "$#" -gt 0 ] && printf '%q ' "$@"; }
+
 SUBCMD="${1:-run}"
 [ $# -gt 0 ] && shift
 
@@ -50,7 +55,7 @@ if [ "$SUBCMD" = "run" ]; then
         --exclude='__pycache__' --exclude='.env*' \
         "$REPO_PATH/" "$FORGE_SERVER:forge-workspaces/$REPO_KEY_Q/"
     # Don't let a non-zero session exit (agent error, Ctrl-C) skip the fetch below.
-    ssh -t "$FORGE_SERVER" "forge run --repo \$HOME/forge-workspaces/$REPO_KEY_Q $(printf '%q ' "$@")" || true
+    ssh -t "$FORGE_SERVER" "forge run --repo \$HOME/forge-workspaces/$REPO_KEY_Q $(q "$@")" || true
 
     # Best-effort fetch of agent's work back from Forgejo.
     FORGEJO_URL="http://${FORGE_SERVER}:${FORGE_FORGEJO_PORT}/${FORGE_FORGEJO_USER}/${REPO}.git"
@@ -129,5 +134,5 @@ except Exception:
     gh pr create --head "$HEAD" --base "$BASE" --title "$TITLE" --body "$BODY"
 else
     FORGE_SERVER="${FORGE_SERVER:-tesseract}"
-    exec ssh -t "$FORGE_SERVER" "forge $(printf %q "$SUBCMD") $(printf '%q ' "$@")"
+    exec ssh -t "$FORGE_SERVER" "forge $(printf %q "$SUBCMD") $(q "$@")"
 fi

--- a/tests/unit/test_workstation_wrapper.py
+++ b/tests/unit/test_workstation_wrapper.py
@@ -100,6 +100,21 @@ def test_syncs_then_invokes_remote_run(shim_bin, tmp_path):
     assert "session ended" in proc.stderr
 
 
+def test_bare_run_passes_no_phantom_empty_arg(shim_bin, tmp_path):
+    # A plain `forge run` (no extra args) must NOT append a stray '' — the
+    # server-side Click rejects it as "Got unexpected extra argument ()".
+    proc, log = run_wrapper(shim_bin, tmp_path, ["run"])
+    run_line = next(l for l in log.splitlines() if "forge run --repo" in l)
+    assert "''" not in run_line
+
+
+def test_bare_passthrough_passes_no_phantom_empty_arg(shim_bin, tmp_path):
+    # Same guard on the passthrough path (e.g. a no-arg `forge status`).
+    proc, log = run_wrapper(shim_bin, tmp_path, ["status"])
+    status_line = next(l for l in log.splitlines() if "forge status" in l)
+    assert "''" not in status_line
+
+
 def test_adds_forgejo_remote_when_absent(shim_bin, tmp_path):
     proc, log = run_wrapper(shim_bin, tmp_path, ["run"])  # GIT_HAS_REMOTE unset
     assert "remote add forgejo http://tesseract:3000/cc_forge_admin/myrepo.git" in log


### PR DESCRIPTION
## Problem

`forge run` (with no extra args) failed from the workstation wrapper:

```
Error: Got unexpected extra argument ()
```

The wrapper builds the remote command with `$(printf '%q ' "$@")`. With no extra args, `printf '%q '` runs its format once against *nothing* and emits a stray `''`, so the server received `forge run --repo <ws> ''` — and Click rejected the empty positional. It only surfaced now because every prior invocation had an argument (`forge run --claude`); a bare `forge run` has none.

## Fix

A small `q()` helper that quotes args but emits nothing when there are none, used in both the `run` path and the passthrough `else` path.

## Tests

- [x] Two regression tests (bare `forge run` and a no-arg passthrough like `forge status`) assert no phantom `''` reaches the server. The pre-existing test only checked a substring, so it missed this.
- [x] 16 wrapper tests pass; `bash -n` clean.

## After merge

Re-copy `scripts/remote-forge/workstation-wrapper` to `~/.local/bin/forge` on the workstation. Server-side forge needs no change.
