### PR TITLE
Add forge prune: remove stale Forgejo branches

### DIFF
--- a/docs/FORGE-USAGE.md
+++ b/docs/FORGE-USAGE.md
@@ -155,6 +155,28 @@ the workstation wrapper makes under the hood to fetch metadata from the server.)
 
 ---
 
+## 5. Prune Stale Forgejo Branches
+
+Every session pushes a branch to Forgejo. Once its PR is closed, merged, or
+abandoned, the branch lingers and clutters the namespace. Clean them up on
+demand:
+
+```bash
+forge prune            # dry run — lists what it would delete
+forge prune --apply    # actually delete the stale branches
+```
+
+A branch is kept when it is the default branch, has an **open** PR, or has a
+commit newer than `--days` (default 7). Everything else is pruned. Closed/merged
+PR *records* are left intact as history.
+
+```bash
+forge prune --days 14              # keep anything touched in the last two weeks
+forge prune --repo-name cc_forge   # target a repo without deriving from origin
+```
+
+---
+
 ## Configuration Reference
 
 Settings are read from `~/.config/forge/config.env`, a `.env` file in the working

--- a/src/cc_forge/cli.py
+++ b/src/cc_forge/cli.py
@@ -79,7 +79,7 @@ def pr_show(pr: int, repo_name: str | None, repo: str) -> None:
 @click.option("--repo-name", default=None,
               help="Forgejo repo name (default: derive from the current repo's origin).")
 @click.option("--repo", default=".", help="Path to git repository (for deriving --repo-name).")
-@click.option("--days", default=7, show_default=True,
+@click.option("--days", default=7, show_default=True, type=click.IntRange(min=0),
               help="Keep branches with a commit newer than this many days.")
 @click.option("--apply", is_flag=True,
               help="Actually delete stale branches (default: dry run).")

--- a/src/cc_forge/cli.py
+++ b/src/cc_forge/cli.py
@@ -76,6 +76,30 @@ def pr_show(pr: int, repo_name: str | None, repo: str) -> None:
 
 
 @main.command()
+@click.option("--repo-name", default=None,
+              help="Forgejo repo name (default: derive from the current repo's origin).")
+@click.option("--repo", default=".", help="Path to git repository (for deriving --repo-name).")
+@click.option("--days", default=7, show_default=True,
+              help="Keep branches with a commit newer than this many days.")
+@click.option("--apply", is_flag=True,
+              help="Actually delete stale branches (default: dry run).")
+def prune(repo_name: str | None, repo: str, days: int, apply: bool) -> None:
+    """Prune stale Forgejo branches (no open PR, not recently active)."""
+    from cc_forge.config import load_config
+    from cc_forge.git import get_repo_name, get_repo_root, is_git_repo
+    from cc_forge.prune import prune_branches, render_summary
+
+    if not repo_name:
+        if not is_git_repo(repo):
+            raise click.ClickException("Run inside a git repo or pass --repo-name.")
+        repo_name = get_repo_name(get_repo_root(repo))
+
+    cfg = load_config()
+    result = prune_branches(cfg, repo_name, days=days, apply=apply)
+    click.echo(render_summary(result))
+
+
+@main.command()
 def status() -> None:
     """Show running forge sessions."""
     from cc_forge.docker import list_forge_containers

--- a/src/cc_forge/forgejo.py
+++ b/src/cc_forge/forgejo.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import quote
+
 import httpx
 
 from cc_forge.config import ForgeConfig
@@ -112,5 +114,11 @@ class ForgejoClient:
         return self._paginate(f"/repos/{owner}/{repo}/branches")
 
     def delete_branch(self, owner: str, repo: str, branch: str) -> None:
-        """Delete a branch by name."""
-        self._request("DELETE", f"/repos/{owner}/{repo}/branches/{branch}")
+        """Delete a branch by name.
+
+        Slashes are kept literal — Forgejo's branch route is a catch-all that
+        expects `feature/x` unencoded — while other URL-special characters that
+        are still legal in a git ref (e.g. `#`, `%`) are percent-encoded.
+        """
+        path = f"/repos/{owner}/{repo}/branches/{quote(branch, safe='/')}"
+        self._request("DELETE", path)

--- a/src/cc_forge/forgejo.py
+++ b/src/cc_forge/forgejo.py
@@ -82,3 +82,35 @@ class ForgejoClient:
         """Fetch a pull request's metadata (head/base refs, title, body, url)."""
         resp = self._request("GET", f"/repos/{owner}/{repo}/pulls/{index}")
         return resp.json()
+
+    def _paginate(self, path: str, params: dict | None = None) -> list[dict]:
+        """Fetch every page of a list endpoint (Forgejo caps a page at 50)."""
+        query = dict(params or {})
+        query["limit"] = 50
+        items: list[dict] = []
+        page = 1
+        while True:
+            query["page"] = page
+            batch = self._request("GET", path, params=query).json()
+            items.extend(batch)
+            if len(batch) < 50:
+                return items
+            page += 1
+
+    def get_repo(self, owner: str, repo: str) -> dict:
+        """Fetch a repository's metadata (includes default_branch)."""
+        return self._request("GET", f"/repos/{owner}/{repo}").json()
+
+    def list_pull_requests(
+        self, owner: str, repo: str, state: str = "all"
+    ) -> list[dict]:
+        """List pull requests (state: open, closed, all)."""
+        return self._paginate(f"/repos/{owner}/{repo}/pulls", {"state": state})
+
+    def list_branches(self, owner: str, repo: str) -> list[dict]:
+        """List branches (each carries name + commit.timestamp)."""
+        return self._paginate(f"/repos/{owner}/{repo}/branches")
+
+    def delete_branch(self, owner: str, repo: str, branch: str) -> None:
+        """Delete a branch by name."""
+        self._request("DELETE", f"/repos/{owner}/{repo}/branches/{branch}")

--- a/src/cc_forge/prune.py
+++ b/src/cc_forge/prune.py
@@ -1,0 +1,144 @@
+"""Prune stale Forgejo branches (no open PR, not recently active).
+
+Forgejo is the agent's workspace: each session pushes a branch and usually
+opens a PR. Once the PR is closed, merged, or abandoned, the branch lingers and
+clutters the namespace. This prunes those leftovers while keeping anything still
+in play. Closed/merged PR *records* are left untouched as historical reference.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import click
+import httpx
+
+from cc_forge.config import ForgeConfig
+from cc_forge.forgejo import ForgejoClient, ForgejoError
+
+
+@dataclass(frozen=True)
+class BranchPlan:
+    """A single branch's disposition."""
+
+    name: str
+    delete: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class PruneResult:
+    plans: list[BranchPlan]
+    applied: bool
+    deleted: list[str]
+    failed: list[tuple[str, str]]  # (branch, error)
+
+
+def _committed_at(branch: dict) -> datetime | None:
+    """Parse a branch's last-commit timestamp, or None if unavailable."""
+    ts = (branch.get("commit") or {}).get("timestamp")
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def plan_prune(
+    branches: list[dict],
+    open_pr_heads: set[str],
+    default_branch: str,
+    cutoff: datetime,
+) -> list[BranchPlan]:
+    """Decide, per branch, whether to keep or delete it.
+
+    Kept: the default branch, any branch with an open PR, and any branch whose
+    last commit is at or after ``cutoff``. Everything else is slated for
+    deletion.
+    """
+    plans: list[BranchPlan] = []
+    for branch in branches:
+        name = branch["name"]
+        if name == default_branch:
+            plans.append(BranchPlan(name, False, "default branch"))
+        elif name in open_pr_heads:
+            plans.append(BranchPlan(name, False, "open PR"))
+        elif (committed := _committed_at(branch)) is not None and committed >= cutoff:
+            plans.append(BranchPlan(name, False, f"active since {committed.date()}"))
+        else:
+            plans.append(BranchPlan(name, True, "no open PR, stale"))
+    return plans
+
+
+def prune_branches(
+    config: ForgeConfig,
+    repo_name: str,
+    *,
+    days: int = 7,
+    apply: bool = False,
+    now: datetime | None = None,
+) -> PruneResult:
+    """Plan (and optionally apply) a prune of stale Forgejo branches.
+
+    Read-only unless ``apply`` is True. Branches with open PRs and the default
+    branch are never deleted, even under ``apply``.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=days)
+
+    try:
+        with ForgejoClient(config) as forgejo:
+            owner = forgejo.get_current_user()
+            default_branch = forgejo.get_repo(owner, repo_name)["default_branch"]
+            branches = forgejo.list_branches(owner, repo_name)
+            open_prs = forgejo.list_pull_requests(owner, repo_name, state="open")
+            open_pr_heads = {pr["head"]["ref"] for pr in open_prs}
+
+            plans = plan_prune(branches, open_pr_heads, default_branch, cutoff)
+            deleted: list[str] = []
+            failed: list[tuple[str, str]] = []
+            if apply:
+                for plan in plans:
+                    if not plan.delete:
+                        continue
+                    try:
+                        forgejo.delete_branch(owner, repo_name, plan.name)
+                        deleted.append(plan.name)
+                    except ForgejoError as e:
+                        failed.append((plan.name, str(e)))
+    except httpx.RequestError as e:
+        raise click.ClickException(f"Forgejo unreachable at {config.forgejo_url}: {e}")
+    except ForgejoError as e:
+        raise click.ClickException(f"Forgejo: {e}")
+
+    return PruneResult(plans=plans, applied=apply, deleted=deleted, failed=failed)
+
+
+def render_summary(result: PruneResult) -> str:
+    """Human-readable kept/deleted summary with per-branch reasons."""
+    kept = [p for p in result.plans if not p.delete]
+    doomed = [p for p in result.plans if p.delete]
+    lines: list[str] = []
+
+    lines.append(f"Kept ({len(kept)}):")
+    for p in kept:
+        lines.append(f"  = {p.name}  ({p.reason})")
+
+    verb = "Deleted" if result.applied else "Would delete"
+    lines.append(f"{verb} ({len(doomed)}):")
+    for p in doomed:
+        mark = "-" if p.name in result.deleted or not result.applied else "!"
+        lines.append(f"  {mark} {p.name}  ({p.reason})")
+
+    if result.failed:
+        lines.append(f"Failed ({len(result.failed)}):")
+        for name, err in result.failed:
+            lines.append(f"  ! {name}  ({err})")
+
+    if not result.applied and doomed:
+        lines.append("")
+        lines.append("Dry run — re-run with --apply to delete.")
+
+    return "\n".join(lines)

--- a/src/cc_forge/prune.py
+++ b/src/cc_forge/prune.py
@@ -41,9 +41,14 @@ def _committed_at(branch: dict) -> datetime | None:
     if not ts:
         return None
     try:
-        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
     except ValueError:
         return None
+    # A timestamp without an offset would be naive; comparing it to the aware
+    # cutoff raises TypeError. Assume UTC when Forgejo omits the offset.
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def plan_prune(
@@ -120,17 +125,22 @@ def render_summary(result: PruneResult) -> str:
     """Human-readable kept/deleted summary with per-branch reasons."""
     kept = [p for p in result.plans if not p.delete]
     doomed = [p for p in result.plans if p.delete]
+    reasons = {p.name: p.reason for p in doomed}
     lines: list[str] = []
 
     lines.append(f"Kept ({len(kept)}):")
     for p in kept:
         lines.append(f"  = {p.name}  ({p.reason})")
 
-    verb = "Deleted" if result.applied else "Would delete"
-    lines.append(f"{verb} ({len(doomed)}):")
-    for p in doomed:
-        mark = "-" if p.name in result.deleted or not result.applied else "!"
-        lines.append(f"  {mark} {p.name}  ({p.reason})")
+    if result.applied:
+        # Count what actually got deleted; failures are reported separately.
+        lines.append(f"Deleted ({len(result.deleted)}):")
+        for name in result.deleted:
+            lines.append(f"  - {name}  ({reasons.get(name, '')})")
+    else:
+        lines.append(f"Would delete ({len(doomed)}):")
+        for p in doomed:
+            lines.append(f"  - {p.name}  ({p.reason})")
 
     if result.failed:
         lines.append(f"Failed ({len(result.failed)}):")

--- a/tests/unit/test_forgejo.py
+++ b/tests/unit/test_forgejo.py
@@ -118,3 +118,35 @@ def test_get_pull_request(client: ForgejoClient, httpx_mock) -> None:
     assert pr["head"]["ref"] == "agent/feature"
     assert pr["base"]["ref"] == "main"
     assert pr["title"] == "Add feature"
+
+
+def test_get_repo(client: ForgejoClient, httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="http://localhost:3000/api/v1/repos/admin/myrepo",
+        json={"name": "myrepo", "default_branch": "main"},
+    )
+    assert client.get_repo("admin", "myrepo")["default_branch"] == "main"
+
+
+def test_delete_branch(client: ForgejoClient, httpx_mock) -> None:
+    import re
+
+    httpx_mock.add_response(
+        url=re.compile(r".*/repos/admin/myrepo/branches/stale$"),
+        method="DELETE",
+        status_code=204,
+    )
+    client.delete_branch("admin", "myrepo", "stale")
+    assert httpx_mock.get_requests()[0].method == "DELETE"
+
+
+def test_list_branches_paginates(client: ForgejoClient, httpx_mock) -> None:
+    import re
+
+    page1 = [{"name": f"b{i}"} for i in range(50)]
+    page2 = [{"name": "b50"}]
+    httpx_mock.add_response(url=re.compile(r".*/branches\?.*page=1.*"), json=page1)
+    httpx_mock.add_response(url=re.compile(r".*/branches\?.*page=2.*"), json=page2)
+    branches = client.list_branches("admin", "myrepo")
+    assert len(branches) == 51
+    assert branches[-1]["name"] == "b50"

--- a/tests/unit/test_forgejo.py
+++ b/tests/unit/test_forgejo.py
@@ -140,6 +140,20 @@ def test_delete_branch(client: ForgejoClient, httpx_mock) -> None:
     assert httpx_mock.get_requests()[0].method == "DELETE"
 
 
+def test_delete_branch_keeps_slashes_encodes_specials(
+    client: ForgejoClient, httpx_mock
+) -> None:
+    import re
+
+    httpx_mock.add_response(
+        url=re.compile(r".*/branches/.*"), method="DELETE", status_code=204
+    )
+    client.delete_branch("admin", "myrepo", "feature/x#1")
+    path = httpx_mock.get_requests()[0].url.raw_path.decode()
+    # Slash stays literal (catch-all route); '#' is percent-encoded.
+    assert path.endswith("/branches/feature/x%231")
+
+
 def test_list_branches_paginates(client: ForgejoClient, httpx_mock) -> None:
     import re
 
@@ -150,3 +164,19 @@ def test_list_branches_paginates(client: ForgejoClient, httpx_mock) -> None:
     branches = client.list_branches("admin", "myrepo")
     assert len(branches) == 51
     assert branches[-1]["name"] == "b50"
+
+
+def test_list_pull_requests_paginates(client: ForgejoClient, httpx_mock) -> None:
+    import re
+
+    page1 = [{"number": i} for i in range(50)]
+    page2 = [{"number": 50}]
+    httpx_mock.add_response(
+        url=re.compile(r".*/pulls\?.*state=all.*page=1.*"), json=page1
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*/pulls\?.*state=all.*page=2.*"), json=page2
+    )
+    prs = client.list_pull_requests("admin", "myrepo", state="all")
+    assert len(prs) == 51
+    assert prs[-1]["number"] == 50

--- a/tests/unit/test_prune.py
+++ b/tests/unit/test_prune.py
@@ -1,0 +1,125 @@
+"""Tests for cc_forge.prune module."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+from cc_forge.config import ForgeConfig
+from cc_forge.prune import plan_prune, prune_branches, render_summary
+
+NOW = datetime(2026, 6, 30, tzinfo=timezone.utc)
+CUTOFF = datetime(2026, 6, 23, tzinfo=timezone.utc)  # NOW - 7 days
+
+
+def _branch(name: str, timestamp: str | None = None) -> dict:
+    commit = {"timestamp": timestamp} if timestamp else {}
+    return {"name": name, "commit": commit}
+
+
+@pytest.fixture()
+def config() -> ForgeConfig:
+    return ForgeConfig(
+        forgejo_url="http://localhost:3000",
+        forgejo_token="test-token",
+        compose_file="/dev/null",
+    )
+
+
+# --- plan_prune (pure classification) ---------------------------------------
+
+def test_keeps_default_branch() -> None:
+    plans = plan_prune([_branch("main", "2020-01-01T00:00:00Z")], set(), "main", CUTOFF)
+    assert plans[0].delete is False
+    assert plans[0].reason == "default branch"
+
+
+def test_keeps_open_pr_branch_even_if_stale() -> None:
+    plans = plan_prune(
+        [_branch("feature/x", "2020-01-01T00:00:00Z")], {"feature/x"}, "main", CUTOFF
+    )
+    assert plans[0].delete is False
+    assert plans[0].reason == "open PR"
+
+
+def test_keeps_recently_active_branch() -> None:
+    plans = plan_prune(
+        [_branch("feature/fresh", "2026-06-28T12:00:00Z")], set(), "main", CUTOFF
+    )
+    assert plans[0].delete is False
+    assert "active since" in plans[0].reason
+
+
+def test_deletes_stale_branch_without_pr() -> None:
+    plans = plan_prune(
+        [_branch("test/hello", "2026-06-01T00:00:00Z")], set(), "main", CUTOFF
+    )
+    assert plans[0].delete is True
+    assert plans[0].reason == "no open PR, stale"
+
+
+def test_deletes_branch_with_missing_timestamp() -> None:
+    plans = plan_prune([_branch("test/hello")], set(), "main", CUTOFF)
+    assert plans[0].delete is True
+
+
+# --- prune_branches (client integration, mocked) ----------------------------
+
+def _register_common(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="http://localhost:3000/api/v1/user", json={"login": "forge-admin"}
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*/repos/forge-admin/myrepo$"),
+        json={"default_branch": "main"},
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*/repos/forge-admin/myrepo/branches.*"),
+        json=[
+            _branch("main", "2026-06-29T00:00:00Z"),
+            _branch("feature/open", "2026-05-01T00:00:00Z"),
+            _branch("test/hello", "2026-05-01T00:00:00Z"),
+        ],
+    )
+    httpx_mock.add_response(
+        url=re.compile(r".*/repos/forge-admin/myrepo/pulls.*"),
+        json=[{"head": {"ref": "feature/open"}}],
+    )
+
+
+def test_dry_run_deletes_nothing(config: ForgeConfig, httpx_mock) -> None:
+    _register_common(httpx_mock)
+    result = prune_branches(config, "myrepo", days=7, apply=False, now=NOW)
+
+    assert result.applied is False
+    assert result.deleted == []
+    doomed = [p.name for p in result.plans if p.delete]
+    assert doomed == ["test/hello"]
+    # no DELETE request was issued
+    assert not any(r.method == "DELETE" for r in httpx_mock.get_requests())
+
+
+def test_apply_deletes_only_stale(config: ForgeConfig, httpx_mock) -> None:
+    _register_common(httpx_mock)
+    httpx_mock.add_response(
+        url=re.compile(r".*/repos/forge-admin/myrepo/branches/test/hello$"),
+        method="DELETE",
+        status_code=204,
+    )
+    result = prune_branches(config, "myrepo", days=7, apply=True, now=NOW)
+
+    assert result.applied is True
+    assert result.deleted == ["test/hello"]
+    deletes = [r for r in httpx_mock.get_requests() if r.method == "DELETE"]
+    assert len(deletes) == 1
+    assert deletes[0].url.path.endswith("/branches/test/hello")
+
+
+def test_render_summary_dry_run_hints_apply(config: ForgeConfig, httpx_mock) -> None:
+    _register_common(httpx_mock)
+    result = prune_branches(config, "myrepo", days=7, apply=False, now=NOW)
+    out = render_summary(result)
+    assert "Would delete (1)" in out
+    assert "--apply" in out


### PR DESCRIPTION
Closes #68.

## What

Adds `forge prune`, a Forgejo-side branch janitor. Every session pushes a branch; once its PR is closed, merged, or abandoned the branch lingers. This removes the leftovers on demand.

A branch is **kept** when it is the default branch, has an **open** PR, or has a commit newer than `--days` (default 7). Everything else is pruned. Closed/merged PR *records* are left intact as history.

```bash
forge prune            # dry run (default) — lists what it would delete, with reasons
forge prune --apply    # actually delete
forge prune --days 14 --repo-name cc_forge
```

Dry-run is the default; `--apply` is required to delete. The default branch and open-PR branches are never deleted, even under `--apply`.

## Design note vs #68

Issue #68 sketched a bash `scripts/forgejo-prune.sh`. Implemented in Python instead — it reuses the existing tested `ForgejoClient` (three new endpoints: `get_repo`, `list_pull_requests`, `list_branches`, `delete_branch`) rather than duplicating the client in curl+jq. #68 anticipated this ("could later be re-implemented as `forge prune`").

## Changes

- `forgejo.py` — paginated `list_*` helpers + `get_repo` / `delete_branch`
- `prune.py` — pure `plan_prune` classifier + `prune_branches` orchestrator + `render_summary`
- `cli.py` — `forge prune` command
- docs — new "Prune Stale Forgejo Branches" section in FORGE-USAGE.md

## Testing

`uv run pytest tests/unit` → 156 passed. New tests cover the classifier (default/open-PR/recent kept, stale deleted, missing-timestamp deleted), dry-run-deletes-nothing, apply-deletes-only-stale, and client pagination.