### PR TITLE
Add promote hub: promote Forgejo PRs and issues to GitHub

### DIFF
--- a/docs/FORGE-USAGE.md
+++ b/docs/FORGE-USAGE.md
@@ -123,10 +123,16 @@ A bare number resolves to whichever it is — Forgejo shares one number space
 between issues and PRs. For a **PR**, promote fetches the agent's branch, pushes
 it to your GitHub remote (`origin` by default), and opens a GitHub PR with the
 same title and body. For an **issue**, it opens a matching GitHub issue. Either
-way the new GitHub item carries a "Promoted from Forgejo …" provenance line, and
-the **source Forgejo item is commented with the GitHub URL and then closed** — so
-"still open" means "not yet promoted", which is exactly what the no-argument walk
-offers you.
+way the new GitHub item carries a "Promoted from Forgejo …" provenance line.
+
+**Duplicate protection.** Before creating anything on GitHub, promote drops a
+marker comment on the Forgejo item (naming the target repo); after the transfer
+it adds the resulting URL and closes the item. That marker is a lock — if a run
+breaks anywhere, the marker stays and a re-run won't create a second copy; it
+tells you the item is already marked and to **delete the marker comment to
+re-promote**. So a marked-and-closed item is a confirmed promote (its comments
+show the repo and the item URL); a marked-but-open one flags a run that broke
+partway. The no-argument walk offers open items.
 
 **Promotion runs where your GitHub credentials are — your machine, never the
 container.** The agent container can reach Forgejo but has no GitHub access, so
@@ -180,7 +186,7 @@ PR *records* are left intact as history.
 
 ```bash
 forge prune --days 14              # keep anything touched in the last two weeks
-forge prune --repo-name cc_forge   # target a repo without deriving from origin
+forge prune --forgejo-repo cc_forge   # target a repo without deriving from origin
 ```
 
 ---

--- a/docs/FORGE-USAGE.md
+++ b/docs/FORGE-USAGE.md
@@ -109,33 +109,41 @@ don't intend to open a GitHub PR at all.
 
 ## 4. Promote to GitHub
 
-When you're satisfied with the Forgejo PR, promote it:
+`forge promote` copies finished work from Forgejo up to GitHub — a PR's branch
+becomes a GitHub PR, an issue becomes a GitHub issue.
 
 ```bash
-forge promote <pr-number>
+forge promote                   # walk every open (unpromoted) issue and PR, confirm each
+forge promote <number>          # promote that PR or issue directly
+forge promote-pr [<number>]     # PRs only    (no number → walk promotable PRs)
+forge promote-issue [<number>]  # issues only  (no number → walk promotable issues)
 ```
 
-`<pr-number>` is the Forgejo PR number (shown in the Forgejo UI). Promote fetches
-the agent's branch, creates a local branch from it, pushes that to your GitHub
-remote (`origin` by default), opens a GitHub PR with the same title and body, and
-prints the URL.
+A bare number resolves to whichever it is — Forgejo shares one number space
+between issues and PRs. For a **PR**, promote fetches the agent's branch, pushes
+it to your GitHub remote (`origin` by default), and opens a GitHub PR with the
+same title and body. For an **issue**, it opens a matching GitHub issue. Either
+way the new GitHub item carries a "Promoted from Forgejo …" provenance line, and
+the **source Forgejo item is commented with the GitHub URL and then closed** — so
+"still open" means "not yet promoted", which is exactly what the no-argument walk
+offers you.
 
 **Promotion runs where your GitHub credentials are — your machine, never the
 container.** The agent container can reach Forgejo but has no GitHub access, so
-crossing to GitHub is a deliberate, human-authorized step. How it plays out
-depends on your setup:
+crossing to GitHub is a deliberate, human-authorized step (in the walk, the
+per-item confirm *is* that gate). Setup depends on where you run it:
 
-- **Single machine** — forge, Forgejo, and you on one host. `forge promote` reads
-  the local Forgejo directly and pushes to GitHub. It needs `gh` authenticated
-  (or `FORGE_GITHUB_TOKEN`), plus the GitHub target set via `FORGE_GITHUB_REPO`
-  (`owner/repo`) or `FORGE_GITHUB_OWNER` in `config.env`.
+- **Single host, or a workstation on the same network as Forgejo** —
+  `forge promote` reads Forgejo over the network and writes GitHub locally, in
+  one process. It needs Forgejo reachable (`FORGE_FORGEJO_URL` +
+  `FORGE_FORGEJO_TOKEN` in `config.env`), `gh` authenticated (or
+  `FORGE_GITHUB_TOKEN`), and the GitHub target via `FORGE_GITHUB_REPO`
+  (`owner/repo`) or `FORGE_GITHUB_OWNER`.
 
-- **Separate workstation + server** — run `forge promote` on your **workstation**
-  (the `scripts/remote-forge/` wrapper). It SSHes to the server for the PR's
-  metadata, then does the push and GitHub PR locally with your `gh` auth,
-  **inferring the repo from your `origin` remote — so no `FORGE_GITHUB_*` config
-  is needed on the workstation**. You need the wrapper installed and SSH to the
-  server.
+- **Via the SSH wrapper** — the older `scripts/remote-forge/` wrapper still
+  handles `promote <pr-number>` by SSHing to the server for metadata then writing
+  GitHub locally. Pointing the workstation directly at Forgejo (above) is simpler
+  and also covers issues and the walk.
 
 ### Options
 

--- a/src/cc_forge/cli.py
+++ b/src/cc_forge/cli.py
@@ -100,9 +100,9 @@ def promote_issue(issue: int | None, repo: str) -> None:
 
 @main.command(name="pr-show")
 @click.argument("pr", type=int)
-@click.option("--repo-name", default=None,
-              help="Forgejo repo name (default: derive from the current repo's origin).")
-@click.option("--repo", default=".", help="Path to git repository (for deriving --repo-name).")
+@click.option("--forgejo-repo", "repo_name", default=None,
+              help="Forgejo repo name (default: derive from --repo's origin).")
+@click.option("--repo", default=".", help="Path to git repository (used to derive --forgejo-repo).")
 def pr_show(pr: int, repo_name: str | None, repo: str) -> None:
     """Print a Forgejo PR's metadata as JSON (head, base, title, body)."""
     import json
@@ -113,7 +113,7 @@ def pr_show(pr: int, repo_name: str | None, repo: str) -> None:
 
     if not repo_name:
         if not is_git_repo(repo):
-            raise click.ClickException("Run inside a git repo or pass --repo-name.")
+            raise click.ClickException("Run inside a git repo or pass --forgejo-repo.")
         repo_name = get_repo_name(get_repo_root(repo))
 
     cfg = load_config()
@@ -121,9 +121,9 @@ def pr_show(pr: int, repo_name: str | None, repo: str) -> None:
 
 
 @main.command()
-@click.option("--repo-name", default=None,
-              help="Forgejo repo name (default: derive from the current repo's origin).")
-@click.option("--repo", default=".", help="Path to git repository (for deriving --repo-name).")
+@click.option("--forgejo-repo", "repo_name", default=None,
+              help="Forgejo repo name (default: derive from --repo's origin).")
+@click.option("--repo", default=".", help="Path to git repository (used to derive --forgejo-repo).")
 @click.option("--days", default=7, show_default=True, type=click.IntRange(min=0),
               help="Keep branches with a commit newer than this many days.")
 @click.option("--apply", is_flag=True,
@@ -136,7 +136,7 @@ def prune(repo_name: str | None, repo: str, days: int, apply: bool) -> None:
 
     if not repo_name:
         if not is_git_repo(repo):
-            raise click.ClickException("Run inside a git repo or pass --repo-name.")
+            raise click.ClickException("Run inside a git repo or pass --forgejo-repo.")
         repo_name = get_repo_name(get_repo_root(repo))
 
     cfg = load_config()

--- a/src/cc_forge/cli.py
+++ b/src/cc_forge/cli.py
@@ -38,19 +38,64 @@ def run(repo: str, agent: str, claude_passthrough: bool) -> None:
     start_session(cfg, repo_path=repo, agent=agent, claude_passthrough=claude_passthrough)
 
 
+def _walk(cfg, repo: str, remote: str, kinds: tuple[str, ...]) -> None:
+    from cc_forge.promote import walk_promotable
+
+    walk_promotable(cfg, repo, remote, kinds, confirm=click.confirm, echo=click.echo)
+
+
 @main.command()
-@click.argument("pr", type=int)
+@click.argument("number", type=int, required=False)
 @click.option("--repo", default=".", help="Path to git repository (default: current directory).")
 @click.option("--remote", default="origin",
               help="Git remote pointing at the GitHub destination (default: origin).")
-def promote(pr: int, repo: str, remote: str) -> None:
-    """Promote a Forgejo PR to a GitHub PR."""
+def promote(number: int | None, repo: str, remote: str) -> None:
+    """Promote a Forgejo PR or issue to GitHub.
+
+    With NUMBER, promote that PR or issue directly (a number resolves to whichever
+    it is). With no NUMBER, walk every promotable (open) issue and PR, confirming
+    each.
+    """
+    from cc_forge.config import load_config
+    from cc_forge.promote import promote_by_number
+
+    cfg = load_config()
+    if number is None:
+        _walk(cfg, repo, remote, ("issue", "pr"))
+    else:
+        click.echo(promote_by_number(cfg, number, repo_path=repo, remote=remote))
+
+
+@main.command(name="promote-pr")
+@click.argument("pr", type=int, required=False)
+@click.option("--repo", default=".", help="Path to git repository (default: current directory).")
+@click.option("--remote", default="origin",
+              help="Git remote pointing at the GitHub destination (default: origin).")
+def promote_pr(pr: int | None, repo: str, remote: str) -> None:
+    """Promote a Forgejo PR to GitHub. With no PR, walk promotable PRs."""
     from cc_forge.config import load_config
     from cc_forge.promote import promote_pull_request
 
     cfg = load_config()
-    url = promote_pull_request(cfg, pr, repo_path=repo, remote=remote)
-    click.echo(url)
+    if pr is None:
+        _walk(cfg, repo, remote, ("pr",))
+    else:
+        click.echo(promote_pull_request(cfg, pr, repo_path=repo, remote=remote))
+
+
+@main.command(name="promote-issue")
+@click.argument("issue", type=int, required=False)
+@click.option("--repo", default=".", help="Path to git repository (default: current directory).")
+def promote_issue(issue: int | None, repo: str) -> None:
+    """Promote a Forgejo issue to GitHub. With no ISSUE, walk promotable issues."""
+    from cc_forge.config import load_config
+    from cc_forge.promote import promote_issue as do_promote_issue
+
+    cfg = load_config()
+    if issue is None:
+        _walk(cfg, repo, "origin", ("issue",))
+    else:
+        click.echo(do_promote_issue(cfg, issue, repo_path=repo))
 
 
 @main.command(name="pr-show")

--- a/src/cc_forge/forgejo.py
+++ b/src/cc_forge/forgejo.py
@@ -122,3 +122,40 @@ class ForgejoClient:
         """
         path = f"/repos/{owner}/{repo}/branches/{quote(branch, safe='/')}"
         self._request("DELETE", path)
+
+    def get_issue(self, owner: str, repo: str, index: int) -> dict:
+        """Fetch an issue by index.
+
+        In Forgejo, pull requests are issues too, so this resolves either — a
+        PR carries a non-null ``pull_request`` field, an issue does not.
+        """
+        return self._request("GET", f"/repos/{owner}/{repo}/issues/{index}").json()
+
+    def list_issues(self, owner: str, repo: str, state: str = "open") -> list[dict]:
+        """List issues (state: open, closed, all), excluding pull requests.
+
+        The Forgejo issues endpoint returns PRs mixed in; they carry a
+        ``pull_request`` field, which we filter out so callers get issues only.
+        """
+        items = self._paginate(
+            f"/repos/{owner}/{repo}/issues", {"state": state, "type": "issues"}
+        )
+        return [i for i in items if not i.get("pull_request")]
+
+    def create_issue_comment(
+        self, owner: str, repo: str, index: int, body: str
+    ) -> dict:
+        """Post a comment on an issue or PR (they share the issue comment API)."""
+        return self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/issues/{index}/comments",
+            json={"body": body},
+        ).json()
+
+    def close_issue(self, owner: str, repo: str, index: int) -> dict:
+        """Close an issue or PR by index (both go through the issues endpoint)."""
+        return self._request(
+            "PATCH",
+            f"/repos/{owner}/{repo}/issues/{index}",
+            json={"state": "closed"},
+        ).json()

--- a/src/cc_forge/forgejo.py
+++ b/src/cc_forge/forgejo.py
@@ -152,6 +152,10 @@ class ForgejoClient:
             json={"body": body},
         ).json()
 
+    def list_issue_comments(self, owner: str, repo: str, index: int) -> list[dict]:
+        """List the comments on an issue or PR (each carries a body)."""
+        return self._paginate(f"/repos/{owner}/{repo}/issues/{index}/comments")
+
     def close_issue(self, owner: str, repo: str, index: int) -> dict:
         """Close an issue or PR by index (both go through the issues endpoint)."""
         return self._request(

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -1,4 +1,8 @@
-"""Promote a Forgejo PR to a GitHub PR (the deliberate Forgejo→GitHub hop)."""
+"""Promote Forgejo PRs and issues to GitHub (the deliberate Forgejo→GitHub hop).
+
+On a successful promote the source Forgejo item gets a back-link comment and is
+closed, so "still open" is the definition of "not yet promoted".
+"""
 
 from __future__ import annotations
 
@@ -62,7 +66,46 @@ def promote_pull_request(
     _warn_on_repo_mismatch(repo_root, remote, github_repo)
     push_to_remote(repo_root, remote, head, set_upstream=False)
 
-    return _gh_pr_create(config, repo_root, github_repo, head, base, title, body)
+    body = body + _provenance_footer("PR", pr_number, meta["url"])
+    url = _gh_pr_create(config, repo_root, github_repo, head, base, title, body)
+    _finalize_forgejo_item(config, repo_name, pr_number, url)
+    return url
+
+
+def promote_issue(config: ForgeConfig, issue_number: int, repo_path: str = ".") -> str:
+    """Open a GitHub issue mirroring a Forgejo issue; return the GitHub URL.
+
+    Unlike a PR, an issue carries no branch — this is purely a metadata copy
+    plus the back-link/close bookkeeping.
+    """
+    if not is_git_repo(repo_path):
+        raise click.ClickException(f"{repo_path} is not a git repository.")
+
+    repo_root = get_repo_root(repo_path)
+    repo_name = get_repo_name(repo_root)
+    github_repo = config.resolve_github_repo(repo_name)
+
+    meta = issue_metadata(config, issue_number, repo_name)
+    if meta["is_pr"]:
+        raise click.ClickException(
+            f"#{issue_number} is a pull request, not an issue — use promote-pr."
+        )
+    body = meta["body"] + _provenance_footer("issue", issue_number, meta["url"])
+    url = _gh_issue_create(config, repo_root, github_repo, meta["title"], body)
+    _finalize_forgejo_item(config, repo_name, issue_number, url)
+    return url
+
+
+def promote_by_number(
+    config: ForgeConfig, number: int, repo_path: str = ".", remote: str = "origin"
+) -> str:
+    """Promote whichever of PR-or-issue carries this number (they share a space)."""
+    if not is_git_repo(repo_path):
+        raise click.ClickException(f"{repo_path} is not a git repository.")
+    repo_name = get_repo_name(get_repo_root(repo_path))
+    if issue_metadata(config, number, repo_name)["is_pr"]:
+        return promote_pull_request(config, number, repo_path=repo_path, remote=remote)
+    return promote_issue(config, number, repo_path=repo_path)
 
 
 def pr_metadata(config: ForgeConfig, pr_number: int, repo_name: str) -> dict:
@@ -85,6 +128,118 @@ def pr_metadata(config: ForgeConfig, pr_number: int, repo_name: str) -> dict:
         "body": pr.get("body") or "",
         "url": pr.get("html_url", ""),
     }
+
+
+def issue_metadata(config: ForgeConfig, index: int, repo_name: str) -> dict:
+    """Read a Forgejo issue/PR: {title, body, url, is_pr}.
+
+    Works for either kind (PRs are issues in Forgejo); ``is_pr`` distinguishes
+    them so callers can route to the right promote path.
+    """
+    try:
+        with ForgejoClient(config) as forgejo:
+            owner = forgejo.get_current_user()
+            item = forgejo.get_issue(owner, repo_name, index)
+    except httpx.RequestError as e:
+        raise click.ClickException(f"Forgejo unreachable at {config.forgejo_url}: {e}")
+    except ForgejoError as e:
+        raise click.ClickException(f"Forgejo: {e}")
+    return {
+        "title": item["title"],
+        "body": item.get("body") or "",
+        "url": item.get("html_url", ""),
+        "is_pr": item.get("pull_request") is not None,
+    }
+
+
+def list_promotable(config: ForgeConfig, repo_name: str) -> list[dict]:
+    """Open issues and PRs, each as {kind: 'issue'|'pr', number, title}.
+
+    Open == not-yet-promoted, since promoting closes the source item. Sorted by
+    number so the walk order is stable.
+    """
+    try:
+        with ForgejoClient(config) as forgejo:
+            owner = forgejo.get_current_user()
+            prs = forgejo.list_pull_requests(owner, repo_name, state="open")
+            issues = forgejo.list_issues(owner, repo_name, state="open")
+    except httpx.RequestError as e:
+        raise click.ClickException(f"Forgejo unreachable at {config.forgejo_url}: {e}")
+    except ForgejoError as e:
+        raise click.ClickException(f"Forgejo: {e}")
+    items = [{"kind": "issue", "number": i["number"], "title": i["title"]} for i in issues]
+    items += [{"kind": "pr", "number": p["number"], "title": p["title"]} for p in prs]
+    return sorted(items, key=lambda it: it["number"])
+
+
+def walk_promotable(
+    config: ForgeConfig,
+    repo_path: str,
+    remote: str,
+    kinds: tuple[str, ...],
+    *,
+    confirm,
+    echo,
+) -> list[tuple[int, str]]:
+    """Walk promotable items of the given kinds, promoting the ones confirmed.
+
+    ``confirm(prompt) -> bool`` and ``echo(msg)`` are injected so the loop is
+    testable without a live terminal. Returns (number, github_url) per promotion.
+    """
+    repo_name = _derive_repo_name(repo_path)
+    items = [it for it in list_promotable(config, repo_name) if it["kind"] in kinds]
+    if not items:
+        echo("Nothing to promote.")
+        return []
+
+    promoted: list[tuple[int, str]] = []
+    for it in items:
+        echo(f"\n{it['kind'].upper()} #{it['number']}: {it['title']}")
+        if not confirm(f"Promote {it['kind']} #{it['number']}?"):
+            continue
+        if it["kind"] == "pr":
+            url = promote_pull_request(config, it["number"], repo_path=repo_path, remote=remote)
+        else:
+            url = promote_issue(config, it["number"], repo_path=repo_path)
+        echo(f"  -> {url}")
+        promoted.append((it["number"], url))
+    return promoted
+
+
+def _derive_repo_name(repo_path: str) -> str:
+    if not is_git_repo(repo_path):
+        raise click.ClickException("Run inside a git repo or pass --repo-name.")
+    return get_repo_name(get_repo_root(repo_path))
+
+
+def _provenance_footer(kind: str, index: int, url: str) -> str:
+    """A one-line trailer linking the GitHub item back to its Forgejo source."""
+    ref = f"Forgejo {kind} #{index}"
+    link = f"[{ref}]({url})" if url else ref
+    return f"\n\n---\n_Promoted from {link}_"
+
+
+def _finalize_forgejo_item(
+    config: ForgeConfig, repo_name: str, index: int, github_url: str
+) -> None:
+    """Best-effort: back-link the Forgejo item to GitHub and close it.
+
+    Non-fatal — the GitHub item already exists, so a Forgejo hiccup here should
+    warn, not fail the promote.
+    """
+    try:
+        with ForgejoClient(config) as forgejo:
+            owner = forgejo.get_current_user()
+            forgejo.create_issue_comment(
+                owner, repo_name, index, f"Promoted to GitHub: {github_url}"
+            )
+            forgejo.close_issue(owner, repo_name, index)
+    except (httpx.RequestError, ForgejoError) as e:
+        click.echo(
+            f"Warning: promoted to {github_url}, but could not close "
+            f"Forgejo #{index}: {e}",
+            err=True,
+        )
 
 
 def _remote_owner_repo(url: str) -> str | None:
@@ -123,21 +278,42 @@ def _gh_pr_create(
     body: str,
 ) -> str:
     """Create a GitHub PR via the gh CLI; return its URL."""
-    env = os.environ.copy()
-    # Prefer the human's ambient gh auth; fall back to the configured token.
-    if config.github_token and not _has_ambient_gh_auth(env):
-        env["GH_TOKEN"] = config.github_token
-
     result = _run_gh(
         ["pr", "create", "-R", github_repo,
          "--head", head, "--base", base,
          "--title", title, "--body", body],
         cwd=repo_root,
-        env=env,
+        env=_gh_env(config),
     )
     if result.returncode != 0:
         raise click.ClickException(f"gh pr create failed: {result.stderr.strip()}")
     return result.stdout.strip()
+
+
+def _gh_issue_create(
+    config: ForgeConfig,
+    repo_root: Path,
+    github_repo: str,
+    title: str,
+    body: str,
+) -> str:
+    """Create a GitHub issue via the gh CLI; return its URL."""
+    result = _run_gh(
+        ["issue", "create", "-R", github_repo, "--title", title, "--body", body],
+        cwd=repo_root,
+        env=_gh_env(config),
+    )
+    if result.returncode != 0:
+        raise click.ClickException(f"gh issue create failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _gh_env(config: ForgeConfig) -> dict[str, str]:
+    """Env for gh: prefer the human's ambient auth, fall back to the config token."""
+    env = os.environ.copy()
+    if config.github_token and not _has_ambient_gh_auth(env):
+        env["GH_TOKEN"] = config.github_token
+    return env
 
 
 def _run_gh(args: list[str], **kwargs) -> subprocess.CompletedProcess:

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -1,12 +1,16 @@
 """Promote Forgejo PRs and issues to GitHub (the deliberate Forgejo→GitHub hop).
 
-On a successful promote the source Forgejo item gets a back-link comment and is
-closed, so "still open" is the definition of "not yet promoted".
+A promote marks the source Forgejo item with a comment *before* creating the
+GitHub item, then records the resulting URL and closes it. That marker is a lock:
+once present, promote refuses to create a duplicate — no matter where a run
+broke — until a human deletes it. So a marked+closed item is a clean success; a
+marked-but-open item means a run failed partway and needs a look.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -48,6 +52,8 @@ def promote_pull_request(
     meta = pr_metadata(config, pr_number, repo_name)
     head, base, title, body = meta["head"], meta["base"], meta["title"], meta["body"]
 
+    _guard_not_promoted(config, repo_name, pr_number)
+
     if not has_remote(repo_root, "forgejo"):
         raise click.ClickException(
             "No 'forgejo' remote found. Run a forge session first "
@@ -66,8 +72,15 @@ def promote_pull_request(
     _warn_on_repo_mismatch(repo_root, remote, github_repo)
     push_to_remote(repo_root, remote, head, set_upstream=False)
 
+    _post_lock(config, repo_name, pr_number, f"https://github.com/{github_repo}")
     body = body + _provenance_footer("PR", pr_number, meta["url"])
-    url = _gh_pr_create(config, repo_root, github_repo, head, base, title, body)
+    try:
+        url = _gh_pr_create(config, repo_root, github_repo, head, base, title, body)
+    except click.ClickException as e:
+        raise click.ClickException(
+            f"{e.message} Forgejo #{pr_number} was marked as promoted — "
+            "delete the marker comment before retrying."
+        )
     _finalize_forgejo_item(config, repo_name, pr_number, url)
     return url
 
@@ -90,8 +103,17 @@ def promote_issue(config: ForgeConfig, issue_number: int, repo_path: str = ".") 
         raise click.ClickException(
             f"#{issue_number} is a pull request, not an issue — use promote-pr."
         )
+
+    _guard_not_promoted(config, repo_name, issue_number)
+    _post_lock(config, repo_name, issue_number, f"https://github.com/{github_repo}")
     body = meta["body"] + _provenance_footer("issue", issue_number, meta["url"])
-    url = _gh_issue_create(config, repo_root, github_repo, meta["title"], body)
+    try:
+        url = _gh_issue_create(config, repo_root, github_repo, meta["title"], body)
+    except click.ClickException as e:
+        raise click.ClickException(
+            f"{e.message} Forgejo #{issue_number} was marked as promoted — "
+            "delete the marker comment before retrying."
+        )
     _finalize_forgejo_item(config, repo_name, issue_number, url)
     return url
 
@@ -197,10 +219,15 @@ def walk_promotable(
         echo(f"\n{it['kind'].upper()} #{it['number']}: {it['title']}")
         if not confirm(f"Promote {it['kind']} #{it['number']}?"):
             continue
-        if it["kind"] == "pr":
-            url = promote_pull_request(config, it["number"], repo_path=repo_path, remote=remote)
-        else:
-            url = promote_issue(config, it["number"], repo_path=repo_path)
+        try:
+            if it["kind"] == "pr":
+                url = promote_pull_request(config, it["number"], repo_path=repo_path, remote=remote)
+            else:
+                url = promote_issue(config, it["number"], repo_path=repo_path)
+        except click.ClickException as e:
+            # One item's failure (already-marked, gh error) shouldn't abort the walk.
+            echo(f"  skipped: {e.message}")
+            continue
         echo(f"  -> {url}")
         promoted.append((it["number"], url))
     return promoted
@@ -208,7 +235,7 @@ def walk_promotable(
 
 def _derive_repo_name(repo_path: str) -> str:
     if not is_git_repo(repo_path):
-        raise click.ClickException("Run inside a git repo or pass --repo-name.")
+        raise click.ClickException(f"{repo_path} is not a git repository.")
     return get_repo_name(get_repo_root(repo_path))
 
 
@@ -219,19 +246,100 @@ def _provenance_footer(kind: str, index: int, url: str) -> str:
     return f"\n\n---\n_Promoted from {link}_"
 
 
-def _finalize_forgejo_item(
-    config: ForgeConfig, repo_name: str, index: int, github_url: str
-) -> None:
-    """Best-effort: back-link the Forgejo item to GitHub and close it.
+# A hidden token embedded in every forge-authored promotion comment. It, not the
+# human-readable text, is what the guard matches — so wording can change freely.
+_MARKER = "<!-- forge-promote -->"
 
-    Non-fatal — the GitHub item already exists, so a Forgejo hiccup here should
-    warn, not fail the promote.
+
+def _marked_comments(comments: list[dict]) -> list[dict]:
+    return [c for c in comments if _MARKER in (c.get("body") or "")]
+
+
+def _promoted_url(marked: list[dict]) -> str | None:
+    """Best URL evidence from marker comments: the result's item URL if present,
+    else any URL (e.g. the lock's repo URL)."""
+    for c in marked:
+        m = re.search(r"Promoted to GitHub:\s*(\S+)", c.get("body") or "")
+        if m:
+            return m.group(1)
+    for c in marked:
+        m = re.search(r"https?://\S+", c.get("body") or "")
+        if m:
+            return m.group(0)
+    return None
+
+
+def _guard_not_promoted(config: ForgeConfig, repo_name: str, number: int) -> None:
+    """Raise if the Forgejo item already carries a promotion marker.
+
+    A marker means a promote was at least started, so we never auto-create a
+    duplicate — the human clears the marker to (re-)promote. Marked+closed reads
+    as a clean success; marked+open means a prior run broke partway.
+    """
+    try:
+        with ForgejoClient(config) as forgejo:
+            owner = forgejo.get_current_user()
+            marked = _marked_comments(
+                forgejo.list_issue_comments(owner, repo_name, number)
+            )
+            if not marked:
+                return
+            closed = forgejo.get_issue(owner, repo_name, number).get("state") == "closed"
+    except httpx.RequestError as e:
+        raise click.ClickException(f"Forgejo unreachable at {config.forgejo_url}: {e}")
+    except ForgejoError as e:
+        raise click.ClickException(f"Forgejo: {e}")
+
+    url = _promoted_url(marked)
+    if closed:
+        raise click.ClickException(
+            f"Forgejo #{number} is already promoted"
+            + (f" → {url}" if url else "")
+            + ". Delete the marker comment to re-promote."
+        )
+    raise click.ClickException(
+        f"Forgejo #{number} is marked as promoted but still open — a prior run "
+        "may have failed partway. Verify it isn't already on GitHub"
+        + (f" ({url})" if url else "")
+        + ", then delete the marker comment and re-run."
+    )
+
+
+def _post_lock(
+    config: ForgeConfig, repo_name: str, number: int, repo_url: str
+) -> None:
+    """Mark the item as being promoted *before* the transfer (the dedup lock).
+
+    Fatal on failure: without the lock there's no duplicate protection, so we
+    refuse to create the GitHub item.
     """
     try:
         with ForgejoClient(config) as forgejo:
             owner = forgejo.get_current_user()
             forgejo.create_issue_comment(
-                owner, repo_name, index, f"Promoted to GitHub: {github_url}"
+                owner, repo_name, number,
+                f"{_MARKER}\nPromoting to {repo_url} — "
+                "delete this comment to re-promote.",
+            )
+    except httpx.RequestError as e:
+        raise click.ClickException(f"Forgejo unreachable at {config.forgejo_url}: {e}")
+    except ForgejoError as e:
+        raise click.ClickException(f"Forgejo: {e}")
+
+
+def _finalize_forgejo_item(
+    config: ForgeConfig, repo_name: str, index: int, github_url: str
+) -> None:
+    """Best-effort: record the GitHub URL on the Forgejo item and close it.
+
+    Non-fatal — the GitHub item already exists and the lock is already in place,
+    so a Forgejo hiccup here should warn, not fail the promote.
+    """
+    try:
+        with ForgejoClient(config) as forgejo:
+            owner = forgejo.get_current_user()
+            forgejo.create_issue_comment(
+                owner, repo_name, index, f"{_MARKER}\nPromoted to GitHub: {github_url}"
             )
             forgejo.close_issue(owner, repo_name, index)
     except (httpx.RequestError, ForgejoError) as e:

--- a/tests/unit/test_forgejo.py
+++ b/tests/unit/test_forgejo.py
@@ -180,3 +180,48 @@ def test_list_pull_requests_paginates(client: ForgejoClient, httpx_mock) -> None
     prs = client.list_pull_requests("admin", "myrepo", state="all")
     assert len(prs) == 51
     assert prs[-1]["number"] == 50
+
+
+def test_get_issue(client: ForgejoClient, httpx_mock) -> None:
+    httpx_mock.add_response(
+        url="http://localhost:3000/api/v1/repos/admin/myrepo/issues/12",
+        json={"title": "Bug", "body": "b", "number": 12},
+    )
+    assert client.get_issue("admin", "myrepo", 12)["number"] == 12
+
+
+def test_list_issues_filters_out_prs(client: ForgejoClient, httpx_mock) -> None:
+    import re
+
+    httpx_mock.add_response(
+        url=re.compile(r".*/issues\?.*"),
+        json=[
+            {"number": 3, "title": "real issue"},
+            {"number": 7, "title": "a pr", "pull_request": {"merged": False}},
+        ],
+    )
+    issues = client.list_issues("admin", "myrepo")
+    assert [i["number"] for i in issues] == [3]
+
+
+def test_create_issue_comment(client: ForgejoClient, httpx_mock) -> None:
+    import re
+
+    httpx_mock.add_response(
+        url=re.compile(r".*/issues/12/comments$"),
+        method="POST",
+        json={"id": 1, "body": "hi"},
+        status_code=201,
+    )
+    assert client.create_issue_comment("admin", "myrepo", 12, "hi")["id"] == 1
+
+
+def test_close_issue(client: ForgejoClient, httpx_mock) -> None:
+    import re
+
+    httpx_mock.add_response(
+        url=re.compile(r".*/issues/12$"),
+        method="PATCH",
+        json={"number": 12, "state": "closed"},
+    )
+    assert client.close_issue("admin", "myrepo", 12)["state"] == "closed"

--- a/tests/unit/test_forgejo.py
+++ b/tests/unit/test_forgejo.py
@@ -225,3 +225,14 @@ def test_close_issue(client: ForgejoClient, httpx_mock) -> None:
         json={"number": 12, "state": "closed"},
     )
     assert client.close_issue("admin", "myrepo", 12)["state"] == "closed"
+
+
+def test_list_issue_comments(client: ForgejoClient, httpx_mock) -> None:
+    import re
+
+    httpx_mock.add_response(
+        url=re.compile(r".*/issues/12/comments\?.*"),
+        json=[{"id": 1, "body": "hi"}, {"id": 2, "body": "there"}],
+    )
+    comments = client.list_issue_comments("admin", "myrepo", 12)
+    assert [c["id"] for c in comments] == [1, 2]

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -38,6 +38,8 @@ def _fake_forgejo(pr: dict) -> MagicMock:
     client.__exit__.return_value = False
     client.get_current_user.return_value = "admin"
     client.get_pull_request.return_value = pr
+    client.get_issue.return_value = {"state": "open"}
+    client.list_issue_comments.return_value = []  # unmarked → guard passes
     return client
 
 
@@ -187,6 +189,8 @@ def _fake_client(**returns) -> MagicMock:
     client.__enter__.return_value = client
     client.__exit__.return_value = False
     client.get_current_user.return_value = "admin"
+    client.get_issue.return_value = {"state": "open"}
+    client.list_issue_comments.return_value = []  # unmarked → guard passes
     for name, value in returns.items():
         getattr(client, name).return_value = value
     return client
@@ -229,9 +233,55 @@ def test_promote_issue_creates_gh_issue_with_provenance_and_closes(monkeypatch):
     assert args[args.index("--title") + 1] == "Bug: thing broken"
     body = args[args.index("--body") + 1]
     assert "Promoted from" in body and "#12" in body
-    # back-link + close on the Forgejo side
-    fake.create_issue_comment.assert_called_once()
+    # lock comment (before) + result comment (after), then close
+    assert fake.create_issue_comment.call_count == 2
+    lock_body = fake.create_issue_comment.call_args_list[0].args[3]
+    result_body = fake.create_issue_comment.call_args_list[1].args[3]
+    assert "github.com/me/cc_forge" in lock_body           # target repo URL
+    assert "https://github.com/me/cc_forge/issues/5" in result_body  # item URL
     fake.close_issue.assert_called_once_with("admin", "cc_forge", 12)
+
+
+def test_promote_issue_blocked_when_already_marked_and_closed(monkeypatch):
+    _wire_repo(monkeypatch)
+    marked = [{"body": "<!-- forge-promote -->\nPromoted to GitHub: https://gh/x/issues/9"}]
+    monkeypatch.setattr(promote_mod, "ForgejoClient",
+                        lambda c: _fake_client(get_issue={**ISSUE, "state": "closed"},
+                                               list_issue_comments=marked))
+    monkeypatch.setattr(promote_mod.subprocess, "run",
+                        lambda *a, **k: pytest.fail("must not create GitHub item"))
+    with pytest.raises(click.ClickException, match="already promoted"):
+        promote_mod.promote_issue(_config(), 9, repo_path="/repo")
+
+
+def test_promote_issue_blocked_when_marked_but_open(monkeypatch):
+    _wire_repo(monkeypatch)
+    marked = [{"body": "<!-- forge-promote -->\nPromoting to https://github.com/me/cc_forge"}]
+    monkeypatch.setattr(promote_mod, "ForgejoClient",
+                        lambda c: _fake_client(get_issue={**ISSUE, "state": "open"},
+                                               list_issue_comments=marked))
+    monkeypatch.setattr(promote_mod.subprocess, "run",
+                        lambda *a, **k: pytest.fail("must not create GitHub item"))
+    with pytest.raises(click.ClickException, match="marked as promoted but still open"):
+        promote_mod.promote_issue(_config(), 9, repo_path="/repo")
+
+
+def test_promote_issue_locks_before_creating(monkeypatch):
+    """The marker lock must be posted before the GitHub item is created."""
+    _wire_repo(monkeypatch)
+    fake = _fake_client(get_issue=ISSUE)
+    monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: fake)
+    order = []
+    fake.create_issue_comment.side_effect = lambda *a, **k: order.append("lock/result")
+
+    def fake_run(args, **kw):
+        order.append("gh")
+        return MagicMock(returncode=0, stdout="https://gh/x/issues/5\n", stderr="")
+
+    monkeypatch.setattr(promote_mod.subprocess, "run", fake_run)
+    promote_mod.promote_issue(_config(), 12, repo_path="/repo")
+    assert order[0] == "lock/result"  # lock posted before gh create
+    assert "gh" in order
 
 
 def test_promote_issue_rejects_a_pr_number(monkeypatch):

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -170,3 +170,171 @@ def test_pr_metadata_unreachable(monkeypatch, err):
 ])
 def test_remote_owner_repo(url, expected):
     assert promote_mod._remote_owner_repo(url) == expected
+
+
+# --- issue promotion + walker ------------------------------------------------
+
+ISSUE = {
+    "title": "Bug: thing broken",
+    "body": "Steps to reproduce.",
+    "html_url": "http://localhost:3000/cc_forge_admin/cc_forge/issues/12",
+}
+PR_AS_ISSUE = {**ISSUE, "pull_request": {"merged": False}}
+
+
+def _fake_client(**returns) -> MagicMock:
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+    client.get_current_user.return_value = "admin"
+    for name, value in returns.items():
+        getattr(client, name).return_value = value
+    return client
+
+
+def _wire_repo(monkeypatch):
+    monkeypatch.setattr(promote_mod, "is_git_repo", lambda p: True)
+    monkeypatch.setattr(promote_mod, "get_repo_root", lambda p: Path("/repo"))
+    monkeypatch.setattr(promote_mod, "get_repo_name", lambda p: "cc_forge")
+
+
+def test_issue_metadata_distinguishes_issue_from_pr(monkeypatch):
+    monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: _fake_client(get_issue=ISSUE))
+    meta = promote_mod.issue_metadata(_config(), 12, "cc_forge")
+    assert meta["is_pr"] is False
+    assert meta["title"] == "Bug: thing broken"
+
+    monkeypatch.setattr(promote_mod, "ForgejoClient",
+                        lambda c: _fake_client(get_issue=PR_AS_ISSUE))
+    assert promote_mod.issue_metadata(_config(), 7, "cc_forge")["is_pr"] is True
+
+
+def test_promote_issue_creates_gh_issue_with_provenance_and_closes(monkeypatch):
+    _wire_repo(monkeypatch)
+    fake = _fake_client(get_issue=ISSUE)
+    monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: fake)
+    captured = {}
+
+    def fake_run(args, **kw):
+        captured["gh_args"] = args
+        return MagicMock(returncode=0,
+                         stdout="https://github.com/me/cc_forge/issues/5\n", stderr="")
+
+    monkeypatch.setattr(promote_mod.subprocess, "run", fake_run)
+    url = promote_mod.promote_issue(_config(), 12, repo_path="/repo")
+
+    assert url == "https://github.com/me/cc_forge/issues/5"
+    args = captured["gh_args"]
+    assert args[:3] == ["gh", "issue", "create"]
+    assert args[args.index("--title") + 1] == "Bug: thing broken"
+    body = args[args.index("--body") + 1]
+    assert "Promoted from" in body and "#12" in body
+    # back-link + close on the Forgejo side
+    fake.create_issue_comment.assert_called_once()
+    fake.close_issue.assert_called_once_with("admin", "cc_forge", 12)
+
+
+def test_promote_issue_rejects_a_pr_number(monkeypatch):
+    _wire_repo(monkeypatch)
+    monkeypatch.setattr(promote_mod, "ForgejoClient",
+                        lambda c: _fake_client(get_issue=PR_AS_ISSUE))
+    with pytest.raises(click.ClickException, match="pull request"):
+        promote_mod.promote_issue(_config(), 7, repo_path="/repo")
+
+
+def test_promote_by_number_routes_to_issue_or_pr(monkeypatch):
+    _wire_repo(monkeypatch)
+    calls = {}
+    monkeypatch.setattr(promote_mod, "promote_issue",
+                        lambda c, n, repo_path=".": calls.setdefault("issue", n))
+    monkeypatch.setattr(promote_mod, "promote_pull_request",
+                        lambda c, n, repo_path=".", remote="origin": calls.setdefault("pr", n))
+
+    monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: _fake_client(get_issue=ISSUE))
+    promote_mod.promote_by_number(_config(), 12, repo_path="/repo")
+    monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: _fake_client(get_issue=PR_AS_ISSUE))
+    promote_mod.promote_by_number(_config(), 7, repo_path="/repo")
+
+    assert calls == {"issue": 12, "pr": 7}
+
+
+def test_list_promotable_merges_issues_and_prs_sorted(monkeypatch):
+    fake = _fake_client(
+        list_pull_requests=[{"number": 7, "title": "PR seven"}],
+        list_issues=[{"number": 3, "title": "Issue three"}],
+    )
+    monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: fake)
+    items = promote_mod.list_promotable(_config(), "cc_forge")
+    assert [(i["kind"], i["number"]) for i in items] == [("issue", 3), ("pr", 7)]
+
+
+def test_walk_promotes_only_confirmed_items(monkeypatch):
+    _wire_repo(monkeypatch)
+    monkeypatch.setattr(promote_mod, "list_promotable", lambda c, rn: [
+        {"kind": "issue", "number": 3, "title": "i3"},
+        {"kind": "pr", "number": 7, "title": "p7"},
+    ])
+    done = []
+    monkeypatch.setattr(promote_mod, "promote_issue",
+                        lambda c, n, repo_path=".": done.append(("issue", n)) or "u-i")
+    monkeypatch.setattr(promote_mod, "promote_pull_request",
+                        lambda c, n, repo_path=".", remote="origin": done.append(("pr", n)) or "u-p")
+
+    answers = iter([True, False])  # promote issue 3, skip pr 7
+    result = promote_mod.walk_promotable(
+        _config(), "/repo", "origin", ("issue", "pr"),
+        confirm=lambda prompt: next(answers), echo=lambda m: None,
+    )
+    assert done == [("issue", 3)]
+    assert result == [(3, "u-i")]
+
+
+def test_walk_filters_by_kind(monkeypatch):
+    _wire_repo(monkeypatch)
+    monkeypatch.setattr(promote_mod, "list_promotable", lambda c, rn: [
+        {"kind": "issue", "number": 3, "title": "i3"},
+        {"kind": "pr", "number": 7, "title": "p7"},
+    ])
+    done = []
+    monkeypatch.setattr(promote_mod, "promote_pull_request",
+                        lambda c, n, repo_path=".", remote="origin": done.append(n))
+    monkeypatch.setattr(promote_mod, "promote_issue",
+                        lambda c, n, repo_path=".": done.append(("issue", n)))
+    promote_mod.walk_promotable(_config(), "/repo", "origin", ("pr",),
+                                confirm=lambda p: True, echo=lambda m: None)
+    assert done == [7]  # issue 3 was never offered
+
+
+def test_walk_reports_nothing_to_promote(monkeypatch):
+    _wire_repo(monkeypatch)
+    monkeypatch.setattr(promote_mod, "list_promotable", lambda c, rn: [])
+    msgs = []
+    result = promote_mod.walk_promotable(_config(), "/repo", "origin", ("issue", "pr"),
+                                         confirm=lambda p: True, echo=msgs.append)
+    assert result == []
+    assert any("Nothing to promote" in m for m in msgs)
+
+
+def test_finalize_is_best_effort(monkeypatch, capsys):
+    import httpx
+
+    def boom(c):
+        m = MagicMock()
+        m.__enter__.return_value = m
+        m.__exit__.return_value = False
+        m.get_current_user.side_effect = httpx.ConnectError("down")
+        return m
+
+    monkeypatch.setattr(promote_mod, "ForgejoClient", boom)
+    promote_mod._finalize_forgejo_item(_config(), "cc_forge", 5, "https://gh/x")  # no raise
+    assert "could not close" in capsys.readouterr().err
+
+
+def test_provenance_footer_links_when_url_present():
+    footer = promote_mod._provenance_footer("issue", 12, "http://x/issues/12")
+    assert "Forgejo issue #12" in footer and "(http://x/issues/12)" in footer
+
+
+def test_provenance_footer_plain_without_url():
+    footer = promote_mod._provenance_footer("PR", 7, "")
+    assert "Forgejo PR #7" in footer and "(" not in footer


### PR DESCRIPTION
Closes #92.

## What

Extends `forge promote` from "PR-by-number only" into a small hub that promotes **both PRs and issues** from Forgejo to GitHub, with an interactive walk. Runs in-process wherever both Forgejo (over the network) and `gh` are reachable — including a workstation on the same LAN as the server, so it needs no SSH wrapper.

```bash
forge promote                   # walk every open (unpromoted) issue and PR, confirm each
forge promote <number>          # promote that PR or issue directly (non-breaking)
forge promote-pr [<number>]     # PRs only    (no number → walk promotable PRs)
forge promote-issue [<number>]  # issues only  (no number → walk promotable issues)
```

## Design

- **Non-breaking:** `forge promote <N>` still promotes PR N as before. A bare number resolves to whichever it is — Forgejo shares one number space between issues and PRs — classified via `get_issue(N)`'s `pull_request` field.
- **Close = dedup:** on a successful promote, the source Forgejo item gets a back-link comment and is **closed**. So "open" == "not yet promoted", which is exactly what the no-arg walk lists — no separate marker/scan needed. (Closing a promoted PR also lets a later `forge prune` sweep its branch — clean handoff with #91.)
- **Provenance:** the new GitHub item carries a `Promoted from Forgejo …` trailer linking back to the source.
- **Best-effort finalize:** the GitHub write is the point of no return; if the Forgejo comment/close then fails, it warns rather than erroring (the GitHub item already exists).
- **Testable walker:** `walk_promotable` takes injected `confirm`/`echo`, so the loop is unit-tested without a live terminal.

## Changes

- `forgejo.py` — `get_issue`, `list_issues` (filters PRs out), `create_issue_comment`, `close_issue`
- `promote.py` — `promote_issue`, `promote_by_number`, `issue_metadata`, `list_promotable`, `walk_promotable`, provenance + finalize helpers; PR flow now adds provenance + finalize
- `cli.py` — `promote [N]` (walk both / by-number), `promote-pr [N]`, `promote-issue [N]`
- docs — rewrote the FORGE-USAGE promote section

## Testing

- `uv run pytest tests/unit` → **173 passed**.
- **Live read-path validated** against the real Forgejo: `list_promotable` (get_current_user + list_pull_requests + list_issues) runs clean. The write path (gh create + close) is exercised by mocked unit tests; a live promote is left to a real item.

## Notes

- Depends on a Forgejo token with `read:user`, `read:repository`, `write:repository`, `read:issue`, `write:issue`.
- The SSH wrapper still handles `promote <pr-number>`; pointing a workstation directly at Forgejo (this PR) is simpler and also covers issues + the walk. Full remote *sessions* remain #42.