### PR TITLE
Run the promote hub locally from the workstation; document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ forge promote-issue [<number>]  # issues only
 ```
 
 A PR's branch becomes a GitHub PR; an issue becomes a GitHub issue. Each promoted
-item links back to its Forgejo source and closes it, so it won't be offered again.
+item is marked with a back-link comment and normally closed, so it drops off the
+walk — and the marker blocks a duplicate even if that close didn't land.
 
 **Why promote runs on your machine:** The agent container can talk to Forgejo
 but not to GitHub. Promotion is the deliberate step where reviewed work crosses

--- a/README.md
+++ b/README.md
@@ -110,16 +110,19 @@ in Forgejo until you're ready to bring it over.
 
 ### Review and Promote
 
-The agent's PR lands in Forgejo (`http://localhost:3000`). Read the diff there,
-then promote it to GitHub when you're satisfied:
+The agent's work lands in Forgejo (`http://localhost:3000`) — a PR, and any issues
+it filed. Review there, then bring what you want over to GitHub:
 
 ```bash
 # From the same repo, on your workstation:
-forge promote <forgejo-pr-number>
+forge promote                   # walk open issues and PRs, confirm each
+forge promote <number>          # promote that PR or issue directly
+forge promote-pr [<number>]     # PRs only
+forge promote-issue [<number>]  # issues only
 ```
 
-`forge promote` fetches the agent's branch from Forgejo, pushes it to your
-GitHub remote, and opens a GitHub PR with the same title and description.
+A PR's branch becomes a GitHub PR; an issue becomes a GitHub issue. Each promoted
+item links back to its Forgejo source and closes it, so it won't be offered again.
 
 **Why promote runs on your machine:** The agent container can talk to Forgejo
 but not to GitHub. Promotion is the deliberate step where reviewed work crosses

--- a/docs/WORKSTATION-SETUP.md
+++ b/docs/WORKSTATION-SETUP.md
@@ -53,6 +53,22 @@ The agent session runs as it always did. You can review the agent's work at
 `http://tesseract:3000` from the workstation's browser, and the agent's
 branches are available locally via `git branch -r | grep forgejo/`.
 
+## Promoting to GitHub
+
+Unlike `run`, the promote family (`forge promote`, `promote-pr`, `promote-issue`)
+runs **locally** on the workstation — it reads the LAN Forgejo directly and writes
+GitHub with your own `gh` auth, no SSH round-trip. It needs a local cc_forge
+checkout (`CC_FORGE_REPO`, default `~/Code/cc_forge`), `uv`, `gh` authenticated
+for the destination, and a `~/.config/forge/config.env` pointing at Forgejo:
+
+```
+FORGE_FORGEJO_URL=http://tesseract:3000
+FORGE_FORGEJO_TOKEN=<token: read:user, read/write:repository, read/write:issue>
+```
+
+Then, from the repo: `forge promote` walks the open Forgejo issues and PRs and
+lets you promote each; `forge promote <number>` promotes one directly.
+
 ## Limitations
 
 - The agent works on the server-side rsync'd copy. Local uncommitted changes
@@ -61,8 +77,8 @@ branches are available locally via `git branch -r | grep forgejo/`.
 - Override the server hostname, Forgejo user, or port via env vars:
   `FORGE_SERVER`, `FORGE_FORGEJO_USER`, `FORGE_FORGEJO_PORT` (defaults:
   `tesseract`, `cc_forge_admin`, `3000`).
-- Workstation `~/.config/forge/config.env` is intentionally absent — the
-  workstation wrapper does not run forge locally, so it does not read config.
+- The workstation reads `~/.config/forge/config.env` for the promote family
+  (Forgejo URL + token); `run` and other subcommands still execute server-side.
 
 ## Removal
 

--- a/docs/WORKSTATION-SETUP.md
+++ b/docs/WORKSTATION-SETUP.md
@@ -55,8 +55,8 @@ branches are available locally via `git branch -r | grep forgejo/`.
 
 ## Promoting to GitHub
 
-Unlike `run`, the promote family (`forge promote`, `promote-pr`, `promote-issue`)
-runs **locally** on the workstation — it reads the LAN Forgejo directly and writes
+Unlike `run`, the promote family (`forge promote`, `forge promote-pr`,
+`forge promote-issue`) runs **locally** on the workstation — it reads the LAN Forgejo directly and writes
 GitHub with your own `gh` auth, no SSH round-trip. It needs a local cc_forge
 checkout (`CC_FORGE_REPO`, default `~/Code/cc_forge`), `uv`, `gh` authenticated
 for the destination, and a `~/.config/forge/config.env` pointing at Forgejo:

--- a/scripts/remote-forge/workstation-wrapper
+++ b/scripts/remote-forge/workstation-wrapper
@@ -1,14 +1,18 @@
 #!/bin/bash
 # Install as ~/.local/bin/forge on a workstation that wants to invoke forge against a
 # remote Forgejo server. For 'forge run' (the default), the current repo is rsynced to
-# the server first; other subcommands pass straight through.
+# the server first. The 'promote' family runs locally against the LAN Forgejo (see
+# below); all other subcommands pass straight through over SSH.
 #
 # Requires:
 # - SSH access to the server (default alias "tesseract" in ~/.ssh/config)
 # - Server-side forge installed (see scripts/remote-forge/server-wrapper)
 # - Server hostname resolvable for Forgejo web UI (see docs/WORKSTATION-SETUP.md)
+# - For promote: a local cc_forge checkout (CC_FORGE_REPO, default ~/Code/cc_forge),
+#   uv, gh auth, and FORGE_FORGEJO_URL/TOKEN in ~/.config/forge/config.env
 #
-# Override defaults via env vars: FORGE_SERVER, FORGE_FORGEJO_USER, FORGE_FORGEJO_PORT.
+# Override defaults via env vars: FORGE_SERVER, FORGE_FORGEJO_USER, FORGE_FORGEJO_PORT,
+# CC_FORGE_REPO.
 #
 # Interim setup for issue #42. Remove when forge learns to talk to a remote Forgejo.
 
@@ -73,65 +77,35 @@ if [ "$SUBCMD" = "run" ]; then
     else
         echo "forge: could not fetch from Forgejo (is $FORGE_SERVER:$FORGE_FORGEJO_PORT reachable?)" >&2
     fi
-elif [ "$SUBCMD" = "promote" ]; then
-    # Split across the host boundary: the server reads its local Forgejo (it has the
-    # token); the workstation does the GitHub write with its own ambient gh auth.
+elif [ "$SUBCMD" = "promote" ] || [ "$SUBCMD" = "promote-pr" ] || [ "$SUBCMD" = "promote-issue" ]; then
+    # The promote hub runs locally on the workstation: it reads the LAN Forgejo
+    # (FORGE_FORGEJO_URL/TOKEN in config.env) and writes GitHub with your own gh
+    # auth. No SSH round-trip — that split was interim scaffolding.
+    command -v uv >/dev/null || {
+        echo "forge: uv is required to run '$SUBCMD' on the workstation" >&2; exit 1; }
+
+    USER_REPO=$(git rev-parse --show-toplevel 2>/dev/null) || {
+        echo "forge: not a git repository" >&2; exit 1; }
+    CC_FORGE_REPO="${CC_FORGE_REPO:-$HOME/Code/cc_forge}"
+    if [ ! -d "$CC_FORGE_REPO" ]; then
+        echo "forge: cc_forge checkout not found (set CC_FORGE_REPO)" >&2; exit 1
+    fi
+
+    # Ensure the 'forgejo' remote on the target repo so promote-pr can fetch the
+    # agent's branch (same URL scheme the run path sets up).
     FORGE_SERVER="${FORGE_SERVER:-tesseract}"
     FORGE_FORGEJO_USER="${FORGE_FORGEJO_USER:-cc_forge_admin}"
     FORGE_FORGEJO_PORT="${FORGE_FORGEJO_PORT:-3000}"
-
-    # promote does its GitHub write locally; both tools are required on the workstation.
-    command -v python3 >/dev/null || {
-        echo "forge: python3 is required for 'forge promote' on the workstation" >&2; exit 1; }
-    command -v gh >/dev/null || {
-        echo "forge: gh CLI is required for 'forge promote' (https://cli.github.com)" >&2; exit 1; }
-
-    PR_NUM="$1"
-    [ -n "$PR_NUM" ] || { echo "forge: usage: forge promote <pr-number>" >&2; exit 1; }
-
-    REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null) || {
-        echo "forge: not a git repository" >&2; exit 1; }
-    REPO=$(basename "$REPO_PATH")
-
-    # 1. Read PR metadata from the server (reads its local Forgejo).
-    META=$(ssh "$FORGE_SERVER" "forge pr-show $(printf %q "$PR_NUM") --repo-name $(printf %q "$REPO")") || {
-        echo "forge: could not read PR $PR_NUM from $FORGE_SERVER" >&2; exit 1; }
-    # Parse once: NUL-delimited fields survive multi-line titles/bodies, and a bad
-    # payload (invalid JSON or missing keys) becomes a clean error, not a traceback.
-    # The inner python3's exit status isn't visible through process substitution, so
-    # validate by field count: a bad payload yields fewer than 4 NUL-delimited fields.
-    mapfile -d '' -t FIELDS < <(printf '%s' "$META" | python3 -c '
-import sys, json
-try:
-    d = json.load(sys.stdin)
-    for k in ("head", "base", "title", "body"):
-        sys.stdout.write(d[k]); sys.stdout.write("\0")
-except Exception:
-    sys.exit(1)
-')
-    [ "${#FIELDS[@]}" -eq 4 ] || {
-        echo "forge: invalid PR metadata from server: $META" >&2; exit 1; }
-    HEAD="${FIELDS[0]}"; BASE="${FIELDS[1]}"; TITLE="${FIELDS[2]}"; BODY="${FIELDS[3]}"
-
-    # 2. Can't reset a checked-out branch.
-    if [ "$(git rev-parse --abbrev-ref HEAD)" = "$HEAD" ]; then
-        echo "forge: branch '$HEAD' is checked out; switch away before promoting" >&2; exit 1
-    fi
-
-    # 3. Ensure the forgejo remote, fetch the agent's branch (read-only).
-    FORGEJO_URL="http://${FORGE_SERVER}:${FORGE_FORGEJO_PORT}/${FORGE_FORGEJO_USER}/${REPO}.git"
+    FORGEJO_URL="http://${FORGE_SERVER}:${FORGE_FORGEJO_PORT}/${FORGE_FORGEJO_USER}/$(basename "$USER_REPO").git"
     if ! CURRENT_URL=$(git remote get-url forgejo 2>/dev/null); then
         git remote add forgejo "$FORGEJO_URL"
     elif [ "$CURRENT_URL" != "$FORGEJO_URL" ]; then
         git remote set-url forgejo "$FORGEJO_URL"
     fi
-    git fetch forgejo >&2
 
-    # 4. Materialize the branch and open the GitHub PR with the workstation's gh
-    #    (no -R: gh infers the repo from origin, so no FORGE_GITHUB_* config is needed here).
-    git branch -f "$HEAD" "forgejo/$HEAD"
-    git push origin "$HEAD" >&2
-    gh pr create --head "$HEAD" --base "$BASE" --title "$TITLE" --body "$BODY"
+    # Delegate to the real Python forge (run from the cc_forge checkout via uv),
+    # pointed at this repo. It does the read/write, dedup lock, and walk itself.
+    cd "$CC_FORGE_REPO" && exec uv run -- forge "$SUBCMD" "$@" --repo "$USER_REPO"
 else
     FORGE_SERVER="${FORGE_SERVER:-tesseract}"
     exec ssh -t "$FORGE_SERVER" "forge $(printf %q "$SUBCMD") $(q "$@")"

--- a/scripts/remote-forge/workstation-wrapper
+++ b/scripts/remote-forge/workstation-wrapper
@@ -83,6 +83,18 @@ elif [ "$SUBCMD" = "promote" ] || [ "$SUBCMD" = "promote-pr" ] || [ "$SUBCMD" = 
     # auth. No SSH round-trip — that split was interim scaffolding.
     command -v uv >/dev/null || {
         echo "forge: uv is required to run '$SUBCMD' on the workstation" >&2; exit 1; }
+    command -v gh >/dev/null || {
+        echo "forge: gh CLI is required for '$SUBCMD' (https://cli.github.com)" >&2; exit 1; }
+
+    # This wrapper sets --repo to the current repo; a second --repo would collide.
+    for a in "$@"; do
+        case "$a" in
+            --repo|--repo=*)
+                echo "forge: this wrapper targets the current repo; do not pass --repo yourself" >&2
+                exit 1
+                ;;
+        esac
+    done
 
     USER_REPO=$(git rev-parse --show-toplevel 2>/dev/null) || {
         echo "forge: not a git repository" >&2; exit 1; }

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -20,6 +20,7 @@ import httpx
 from cc_forge.config import ForgeConfig
 from cc_forge.forgejo import ForgejoClient, ForgejoError
 from cc_forge.git import (
+    GitError,
     create_branch_from_ref,
     fetch_remote,
     get_current_branch,
@@ -59,18 +60,29 @@ def promote_pull_request(
             "No 'forgejo' remote found. Run a forge session first "
             "(the workstation wrapper adds it)."
         )
-    fetch_remote(repo_root, "forgejo")
+    try:
+        fetch_remote(repo_root, "forgejo")
+    except GitError as e:
+        raise click.ClickException(
+            f"Could not fetch the 'forgejo' remote (is Forgejo reachable?): {e}"
+        )
     if get_current_branch(repo_root) == head:
         raise click.ClickException(
             f"Branch '{head}' is currently checked out; switch to another branch "
             "before promoting."
         )
-    create_branch_from_ref(repo_root, head, f"forgejo/{head}")
+    try:
+        create_branch_from_ref(repo_root, head, f"forgejo/{head}")
+    except GitError as e:
+        raise click.ClickException(f"Could not materialize branch '{head}': {e}")
 
     if not has_remote(repo_root, remote):
         raise click.ClickException(f"No '{remote}' remote to push to.")
     _warn_on_repo_mismatch(repo_root, remote, github_repo)
-    push_to_remote(repo_root, remote, head, set_upstream=False)
+    try:
+        push_to_remote(repo_root, remote, head, set_upstream=False)
+    except GitError as e:
+        raise click.ClickException(f"Could not push '{head}' to '{remote}': {e}")
 
     _post_lock(config, repo_name, pr_number, f"https://github.com/{github_repo}")
     body = body + _provenance_footer("PR", pr_number, meta["url"])

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -139,6 +139,19 @@ def test_promote_errors_when_gh_missing(monkeypatch):
         promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
 
 
+def test_promote_git_fetch_failure_becomes_clean_message(monkeypatch):
+    from cc_forge.git import GitError
+
+    _wire(monkeypatch)
+
+    def boom(root, remote):
+        raise GitError("Could not resolve host")
+
+    monkeypatch.setattr(promote_mod, "fetch_remote", boom)
+    with pytest.raises(click.ClickException, match="is Forgejo reachable"):
+        promote_mod.promote_pull_request(_config(), 7, repo_path="/repo")
+
+
 def test_pr_metadata_happy(monkeypatch):
     monkeypatch.setattr(promote_mod, "ForgejoClient", lambda c: _fake_forgejo(PR))
     meta = promote_mod.pr_metadata(_config(), 7, "cc_forge")

--- a/tests/unit/test_workstation_wrapper.py
+++ b/tests/unit/test_workstation_wrapper.py
@@ -207,6 +207,16 @@ def test_promote_passes_number_through(shim_bin, tmp_path):
     assert "uv run -- forge promote 5 --repo /home/u/myrepo" in log
 
 
+def test_promote_rejects_user_repo_flag(shim_bin, tmp_path):
+    # The wrapper sets --repo itself; a user-passed one would collide.
+    proc, log = run_wrapper(
+        shim_bin, tmp_path, ["promote", "--repo", "/foo"], CC_FORGE_REPO=str(tmp_path)
+    )
+    assert proc.returncode == 1
+    assert "do not pass --repo" in proc.stderr
+    assert "uv run" not in log
+
+
 def test_promote_ensures_forgejo_remote(shim_bin, tmp_path):
     # No forgejo remote yet → the wrapper adds one before delegating.
     proc, log = run_wrapper(shim_bin, tmp_path, ["promote"], CC_FORGE_REPO=str(tmp_path))

--- a/tests/unit/test_workstation_wrapper.py
+++ b/tests/unit/test_workstation_wrapper.py
@@ -34,7 +34,9 @@ exit "${RSYNC_RC:-0}"
 _GIT_SHIM = """#!/bin/bash
 echo "git $*" >> "$CALL_LOG"
 case "$1 $2" in
-    "rev-parse --show-toplevel") echo "${FAKE_REPO_PATH:-/home/u/myrepo}"; exit 0;;
+    "rev-parse --show-toplevel")
+        [ -n "$GIT_TOPLEVEL_RC" ] && exit "$GIT_TOPLEVEL_RC"
+        echo "${FAKE_REPO_PATH:-/home/u/myrepo}"; exit 0;;
     "rev-parse --abbrev-ref") echo "${FAKE_CURRENT_BRANCH:-main}"; exit 0;;
     "remote get-url")
         if [ -n "$GIT_HAS_REMOTE" ]; then echo "$GIT_REMOTE_URL"; exit 0; fi
@@ -51,6 +53,11 @@ echo "https://github.com/me/myrepo/pull/9"
 exit "${GH_RC:-0}"
 """
 
+_UV_SHIM = """#!/bin/bash
+echo "uv $*" >> "$CALL_LOG"
+exit "${UV_RC:-0}"
+"""
+
 
 @pytest.fixture()
 def shim_bin(tmp_path: Path) -> Path:
@@ -58,7 +65,8 @@ def shim_bin(tmp_path: Path) -> Path:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     for name, body in (
-        ("ssh", _SSH_SHIM), ("rsync", _RSYNC_SHIM), ("git", _GIT_SHIM), ("gh", _GH_SHIM)
+        ("ssh", _SSH_SHIM), ("rsync", _RSYNC_SHIM), ("git", _GIT_SHIM),
+        ("gh", _GH_SHIM), ("uv", _UV_SHIM),
     ):
         shim = bin_dir / name
         shim.write_text(body)
@@ -70,6 +78,9 @@ def run_wrapper(shim_bin: Path, tmp_path: Path, args: list[str], **env_overrides
     """Run the wrapper with shims on PATH. Returns (proc, call_log_text)."""
     call_log = tmp_path / "calls.log"
     env = dict(os.environ)
+    # Drop any BASH_ENV hook (e.g. mise's shell activation) — it re-prepends its
+    # own shims dir on bash startup, which would shadow our PATH shims (uv, etc.).
+    env.pop("BASH_ENV", None)
     env["PATH"] = f"{shim_bin}:{env['PATH']}"
     env["CALL_LOG"] = str(call_log)
     env.setdefault("FAKE_REPO_PATH", "/home/u/myrepo")
@@ -179,58 +190,40 @@ def test_passthrough_subcommand_skips_rsync(shim_bin, tmp_path):
     assert "forge status" in log
 
 
-_META = '{"head":"agent/feature","base":"main","title":"Add it","body":"Body."}'
-
-
-def test_promote_reads_metadata_then_writes_github(shim_bin, tmp_path):
-    proc, log = run_wrapper(
-        shim_bin, tmp_path, ["promote", "4"],
-        PR_META_JSON=_META,
-        GIT_HAS_REMOTE="1",
-        GIT_REMOTE_URL="http://tesseract:3000/cc_forge_admin/myrepo.git",
-    )
+@pytest.mark.parametrize("sub", ["promote", "promote-pr", "promote-issue"])
+def test_promote_family_delegates_to_local_forge(shim_bin, tmp_path, sub):
+    proc, log = run_wrapper(shim_bin, tmp_path, [sub], CC_FORGE_REPO=str(tmp_path))
     assert proc.returncode == 0, proc.stderr
-    # metadata read happens on the server, not locally
-    assert "forge pr-show 4 --repo-name myrepo" in log
-    # branch materialized + pushed to origin (GitHub) locally
-    assert "git branch -f agent/feature forgejo/agent/feature" in log
-    assert "git push origin agent/feature" in log
-    # GitHub PR opened with the carried metadata, no -R (inferred from origin)
-    assert "gh pr create --head agent/feature --base main --title Add it --body Body." in log
-    assert "-R" not in log
-    # the gh PR URL is surfaced on stdout
-    assert "https://github.com/me/myrepo/pull/9" in proc.stdout
-
-
-def test_promote_blocks_when_head_checked_out(shim_bin, tmp_path):
-    proc, log = run_wrapper(
-        shim_bin, tmp_path, ["promote", "4"],
-        PR_META_JSON=_META,
-        FAKE_CURRENT_BRANCH="agent/feature",
-    )
-    assert proc.returncode == 1
-    assert "checked out" in proc.stderr
-    assert "gh pr create" not in log  # never reached the GitHub write
-
-
-def test_promote_requires_pr_number(shim_bin, tmp_path):
-    proc, log = run_wrapper(shim_bin, tmp_path, ["promote"])
-    assert proc.returncode == 1
-    assert "usage" in proc.stderr
+    # Delegated to the local Python forge, pointed at the current repo.
+    assert f"uv run -- forge {sub} --repo /home/u/myrepo" in log
+    # Runs locally — no SSH round-trip, no server-side pr-show.
     assert "ssh" not in log
+    assert "pr-show" not in log
 
 
-def test_promote_fails_when_pr_show_fails(shim_bin, tmp_path):
-    proc, log = run_wrapper(
-        shim_bin, tmp_path, ["promote", "4"], PR_META_JSON=_META, SSH_PRSHOW_RC="1",
-    )
+def test_promote_passes_number_through(shim_bin, tmp_path):
+    proc, log = run_wrapper(shim_bin, tmp_path, ["promote", "5"], CC_FORGE_REPO=str(tmp_path))
+    assert proc.returncode == 0, proc.stderr
+    assert "uv run -- forge promote 5 --repo /home/u/myrepo" in log
+
+
+def test_promote_ensures_forgejo_remote(shim_bin, tmp_path):
+    # No forgejo remote yet → the wrapper adds one before delegating.
+    proc, log = run_wrapper(shim_bin, tmp_path, ["promote"], CC_FORGE_REPO=str(tmp_path))
+    assert proc.returncode == 0, proc.stderr
+    assert "git remote add forgejo http://tesseract:3000/cc_forge_admin/myrepo.git" in log
+
+
+def test_promote_requires_git_repo(shim_bin, tmp_path):
+    proc, log = run_wrapper(shim_bin, tmp_path, ["promote"], GIT_TOPLEVEL_RC="1")
     assert proc.returncode == 1
-    assert "could not read PR 4" in proc.stderr
-    assert "gh pr create" not in log
+    assert "not a git repository" in proc.stderr
+    assert "uv run" not in log
 
 
-def test_promote_rejects_invalid_metadata(shim_bin, tmp_path):
-    proc, log = run_wrapper(shim_bin, tmp_path, ["promote", "4"], PR_META_JSON="not json")
+def test_promote_requires_cc_forge_checkout(shim_bin, tmp_path):
+    missing = tmp_path / "nope"
+    proc, log = run_wrapper(shim_bin, tmp_path, ["promote"], CC_FORGE_REPO=str(missing))
     assert proc.returncode == 1
-    assert "invalid PR metadata" in proc.stderr
-    assert "gh pr create" not in log
+    assert "checkout not found" in proc.stderr
+    assert "uv run" not in log


### PR DESCRIPTION
Two related changes now that the promote hub (#93) has landed:

**Run the promote hub locally from the workstation** (Closes #94). The `workstation-wrapper` delegates `promote` / `promote-pr` / `promote-issue` to the local Python forge (via `uv`, from the `CC_FORGE_REPO` checkout), pointed at the current repo. It reads the LAN Forgejo (`config.env`) and writes GitHub with your own `gh` auth — no SSH round-trip. The old server-side `pr-show` + manual push + `gh pr create` dance is removed; that split was interim scaffolding and isn't wanted as a fallback. Non-promote subcommands still pass through over SSH.

**Docs.** The README quickstart now shows the full promote command set, and `docs/WORKSTATION-SETUP.md` documents the local-promote requirements (`config.env` with Forgejo URL + token, `uv`, `gh`, `CC_FORGE_REPO`) and corrects the stale "workstation never runs forge locally" note.

## Testing
- Wrapper unit tests rewritten for local delegation (shim `uv`, assert on the delegated `forge … --repo` call).
- `uv run pytest tests/unit` → 179 passed.