### PR TITLE
Fix agent clone when ROOT_URL is a LAN hostname

### DIFF
--- a/src/cc_forge/docker.py
+++ b/src/cc_forge/docker.py
@@ -27,6 +27,18 @@ def _rewrite_url(url: str, docker_host: str) -> str:
     return url
 
 
+def _internal_forgejo_url(url: str) -> str:
+    """Point a Forgejo URL at the in-network container (``forge-forgejo:3000``).
+
+    The agent reaches Forgejo only by that container name on forge-network,
+    whatever host ROOT_URL / FORGE_FORGEJO_URL exposes to humans (localhost, a
+    LAN hostname, ...). Preserves scheme, path, and query.
+    """
+    from urllib.parse import urlsplit, urlunsplit
+
+    return urlunsplit(urlsplit(url)._replace(netloc="forge-forgejo:3000"))
+
+
 def _docker_client() -> docker.DockerClient:
     return docker.from_env()
 
@@ -263,7 +275,7 @@ def _inject_git_credentials(container, config: ForgeConfig) -> None:
     if not config.forgejo_token or not config.forgejo_url:
         return
 
-    forgejo_url = _rewrite_url(config.forgejo_url, "forge-forgejo")
+    forgejo_url = _internal_forgejo_url(config.forgejo_url)
     parts = urlsplit(forgejo_url)
     # git's store helper matches on scheme + host:port; drop any path/query.
     # Percent-encode the token so reserved chars (@ : /) don't corrupt the URL.
@@ -297,7 +309,7 @@ def _inject_shim_credentials(container, config: ForgeConfig) -> None:
     # Each pair: (env var name the shim expects, config value to write)
     pairs: list[tuple[str, str]] = []
     if config.forgejo_url:
-        pairs.append(("FORGEJO_URL", _rewrite_url(config.forgejo_url, "forge-forgejo")))
+        pairs.append(("FORGEJO_URL", _internal_forgejo_url(config.forgejo_url)))
     if config.forgejo_token:
         pairs.append(("FORGEJO_TOKEN", config.forgejo_token))
     if config.github_token:
@@ -338,8 +350,9 @@ def run_agent_container(
 
     container_name = f"{CONTAINER_PREFIX}{repo_name}-{int(time.time())}"
 
-    # Rewrite URLs for container network: localhost → Docker service names.
-    clone_url = _rewrite_url(repo_url, "forge-forgejo")
+    # The agent reaches Forgejo only as forge-forgejo:3000 on forge-network,
+    # regardless of the ROOT_URL the clone URL was built from.
+    clone_url = _internal_forgejo_url(repo_url)
 
     # Tokens (Forgejo + GitHub) are injected via files, not env vars, so they
     # are not visible to `docker inspect`. See _inject_git_credentials and

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -12,6 +12,7 @@ from cc_forge.docker import (
     AGENT_UID,
     SHIM_CREDENTIALS_PATH,
     _rewrite_url,
+    _internal_forgejo_url,
     _ollama_environment,
     _claude_environment,
     _claude_credentials_path,
@@ -94,6 +95,24 @@ class TestRewriteUrl:
     def test_query_params_preserved(self):
         assert _rewrite_url("http://localhost:3000/api?token=abc", "forge-forgejo") == \
             "http://forge-forgejo:3000/api?token=abc"
+
+
+class TestInternalForgejoUrl:
+    def test_localhost(self):
+        assert _internal_forgejo_url("http://localhost:3000") == "http://forge-forgejo:3000"
+
+    def test_lan_hostname_with_path(self):
+        # ROOT_URL set to a LAN host must still resolve to the in-network container.
+        assert _internal_forgejo_url("http://tesseract:3000/alice/widgets.git") == \
+            "http://forge-forgejo:3000/alice/widgets.git"
+
+    def test_127_with_path(self):
+        assert _internal_forgejo_url("http://127.0.0.1:3000/x") == \
+            "http://forge-forgejo:3000/x"
+
+    def test_forces_internal_port_and_preserves_scheme(self):
+        assert _internal_forgejo_url("https://example.com:8443/owner/repo.git") == \
+            "https://forge-forgejo:3000/owner/repo.git"
 
 
 class TestOllamaEnvironment:


### PR DESCRIPTION
Parameterizing Forgejo `ROOT_URL` in #97 exposed a latent bug in `forge run`.

The agent reaches Forgejo only as `forge-forgejo:3000` on `forge-network`, so `forge` rewrites the Forgejo host before handing URLs to the container. But that rewrite (`_rewrite_url`) only handled `localhost`/`127.0.0.1`. Once `ROOT_URL` is set to a LAN hostname (e.g. `tesseract:3000`), the agent's clone URL — derived from the API `clone_url`, which follows `ROOT_URL` — passed through unchanged, and the container could not resolve that host on `forge-network`. Clone failed.

Add `_internal_forgejo_url()`, which forces any Forgejo URL to `forge-forgejo:3000` (preserving scheme/path), and use it for the three agent-facing Forgejo URLs: the clone `REPO_URL`, the injected `.git-credentials`, and the shim `FORGEJO_URL`. This decouples the agent's in-network addressing from the human-facing `ROOT_URL`, so browsing on a LAN hostname and agent clones both work.

`_rewrite_url` is unchanged (still used for the Ollama proxies). Adds unit tests for the new helper; full unit suite passes (185).