### PR TITLE
Richer context in the forge promote walk

### DIFF
--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -238,14 +238,23 @@ def list_promotable(config: ForgeConfig, repo_name: str) -> list[dict]:
 
 
 def _first_paragraph(body: str, limit: int = 200) -> str:
-    """First real text paragraph of a body: skip markdown headings and blanks,
-    collapse whitespace, and cap the length."""
-    for para in body.strip().split("\n\n"):
-        text = " ".join(para.split())
-        if not text or text.startswith("#"):
-            continue
-        return text if len(text) <= limit else text[: limit - 3].rstrip() + "..."
-    return ""
+    """First real text paragraph of a body: skip leading markdown headings and
+    blanks, collect until the next blank line or heading, collapse whitespace,
+    and cap the length (even a heading directly above text, no blank line)."""
+    picked: list[str] = []
+    for line in body.strip().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            if picked:
+                break  # a blank line or heading ends the first paragraph
+            continue   # still skipping leading blanks/headings
+        picked.append(stripped)
+    text = " ".join(picked)
+    if len(text) <= limit:
+        return text
+    if limit < 3:  # no room for the "..." — hard-cut so we never exceed limit
+        return text[:limit]
+    return text[: limit - 3].rstrip() + "..."
 
 
 def _promotable_summary(it: dict) -> str:

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -273,7 +273,7 @@ def _promotable_summary(it: dict) -> str:
         meta.append(f"opened {it['created_at'][:10]}")
     if meta:
         lines.append("   " + " | ".join(meta))
-    excerpt = _first_paragraph(it.get("body", ""))
+    excerpt = _first_paragraph(it.get("body") or "")
     if excerpt:
         lines.append("   " + excerpt)
     if it.get("url"):

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -195,7 +195,8 @@ def issue_metadata(config: ForgeConfig, index: int, repo_name: str) -> dict:
 
 
 def list_promotable(config: ForgeConfig, repo_name: str) -> list[dict]:
-    """Open issues and PRs, each as {kind: 'issue'|'pr', number, title}.
+    """Open issues and PRs as rich dicts (kind, number, title, body, url, dates,
+    and head/base for PRs) for a context-rich promote walk.
 
     Open == not-yet-promoted, since promoting closes the source item. Sorted by
     number so the walk order is stable.
@@ -209,9 +210,61 @@ def list_promotable(config: ForgeConfig, repo_name: str) -> list[dict]:
         raise click.ClickException(f"Forgejo unreachable at {config.forgejo_url}: {e}")
     except ForgejoError as e:
         raise click.ClickException(f"Forgejo: {e}")
-    items = [{"kind": "issue", "number": i["number"], "title": i["title"]} for i in issues]
-    items += [{"kind": "pr", "number": p["number"], "title": p["title"]} for p in prs]
+    items = [
+        {
+            "kind": "issue",
+            "number": i["number"],
+            "title": i["title"],
+            "body": i.get("body") or "",
+            "url": i.get("html_url", ""),
+            "created_at": i.get("created_at", ""),
+        }
+        for i in issues
+    ]
+    items += [
+        {
+            "kind": "pr",
+            "number": p["number"],
+            "title": p["title"],
+            "body": p.get("body") or "",
+            "url": p.get("html_url", ""),
+            "created_at": p.get("created_at", ""),
+            "head": (p.get("head") or {}).get("ref", ""),
+            "base": (p.get("base") or {}).get("ref", ""),
+        }
+        for p in prs
+    ]
     return sorted(items, key=lambda it: it["number"])
+
+
+def _first_paragraph(body: str, limit: int = 200) -> str:
+    """First real text paragraph of a body: skip markdown headings and blanks,
+    collapse whitespace, and cap the length."""
+    for para in body.strip().split("\n\n"):
+        text = " ".join(para.split())
+        if not text or text.startswith("#"):
+            continue
+        return text if len(text) <= limit else text[: limit - 3].rstrip() + "..."
+    return ""
+
+
+def _promotable_summary(it: dict) -> str:
+    """Context block for one promotable item: title, branch/opened-date, a
+    first-paragraph excerpt, and the Forgejo URL."""
+    lines = [f"{it['kind'].upper()} #{it['number']}: {it['title']}"]
+    meta = []
+    if it.get("head") and it.get("base"):
+        meta.append(f"{it['head']} -> {it['base']}")
+    if it.get("created_at"):
+        meta.append(f"opened {it['created_at'][:10]}")
+    if meta:
+        lines.append("   " + " | ".join(meta))
+    excerpt = _first_paragraph(it.get("body", ""))
+    if excerpt:
+        lines.append("   " + excerpt)
+    if it.get("url"):
+        lines.append("   " + it["url"])
+    return "\n".join(lines)
 
 
 def walk_promotable(
@@ -236,7 +289,7 @@ def walk_promotable(
 
     promoted: list[tuple[int, str]] = []
     for it in items:
-        echo(f"\n{it['kind'].upper()} #{it['number']}: {it['title']}")
+        echo(f"\n{_promotable_summary(it)}")
         if not confirm(f"Promote {it['kind']} #{it['number']}?"):
             continue
         try:

--- a/src/cc_forge/promote.py
+++ b/src/cc_forge/promote.py
@@ -237,6 +237,11 @@ def list_promotable(config: ForgeConfig, repo_name: str) -> list[dict]:
     return sorted(items, key=lambda it: it["number"])
 
 
+# Markdown ATX heading: 1–6 '#' then whitespace or end of line — so "#1 ..." refs
+# and numbered lists are kept, only real headings ("## Summary") are skipped.
+_HEADING_RE = re.compile(r"#{1,6}(?:\s|$)")
+
+
 def _first_paragraph(body: str, limit: int = 200) -> str:
     """First real text paragraph of a body: skip leading markdown headings and
     blanks, collect until the next blank line or heading, collapse whitespace,
@@ -244,7 +249,7 @@ def _first_paragraph(body: str, limit: int = 200) -> str:
     picked: list[str] = []
     for line in body.strip().splitlines():
         stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
+        if not stripped or _HEADING_RE.match(stripped):
             if picked:
                 break  # a blank line or heading ends the first paragraph
             continue   # still skipping leading blanks/headings

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -355,6 +355,8 @@ def test_first_paragraph_skips_headings_and_caps():
     assert promote_mod._first_paragraph("## Summary\nExpands the shim.") == "Expands the shim."
     # limit < 3 has no room for the ellipsis and must never exceed the limit.
     assert promote_mod._first_paragraph("hello world", limit=2) == "he"
+    # "#1 ..." is an issue reference / numbered list, not a heading — keep it.
+    assert promote_mod._first_paragraph("#1 is the top priority.") == "#1 is the top priority."
 
 
 def test_promotable_summary_renders_context():

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -351,6 +351,10 @@ def test_first_paragraph_skips_headings_and_caps():
     capped = promote_mod._first_paragraph("x" * 250, limit=50)
     assert len(capped) == 50 and capped.endswith("...")
     assert promote_mod._first_paragraph("") == ""
+    # Heading directly above text (no blank line) still finds the text.
+    assert promote_mod._first_paragraph("## Summary\nExpands the shim.") == "Expands the shim."
+    # limit < 3 has no room for the ellipsis and must never exceed the limit.
+    assert promote_mod._first_paragraph("hello world", limit=2) == "he"
 
 
 def test_promotable_summary_renders_context():

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -345,6 +345,33 @@ def test_list_promotable_merges_issues_and_prs_sorted(monkeypatch):
     assert [(i["kind"], i["number"]) for i in items] == [("issue", 3), ("pr", 7)]
 
 
+def test_first_paragraph_skips_headings_and_caps():
+    body = "## Summary\n\nExpands the shim from 4 to 8 commands.\n\nMore detail."
+    assert promote_mod._first_paragraph(body) == "Expands the shim from 4 to 8 commands."
+    capped = promote_mod._first_paragraph("x" * 250, limit=50)
+    assert len(capped) == 50 and capped.endswith("...")
+    assert promote_mod._first_paragraph("") == ""
+
+
+def test_promotable_summary_renders_context():
+    out = promote_mod._promotable_summary({
+        "kind": "pr", "number": 12, "title": "Expand gh shim",
+        "body": "## Summary\n\nDoes the thing.", "head": "feature/x", "base": "main",
+        "created_at": "2026-07-13T11:20:54-05:00", "url": "http://forge/pulls/12",
+    })
+    assert "PR #12: Expand gh shim" in out
+    assert "feature/x -> main" in out
+    assert "opened 2026-07-13" in out
+    assert "Does the thing." in out
+    assert "http://forge/pulls/12" in out
+
+
+def test_promotable_summary_minimal_item_does_not_crash():
+    # A bare item (e.g. a mocked one) renders just the title line.
+    out = promote_mod._promotable_summary({"kind": "issue", "number": 5, "title": "t"})
+    assert out == "ISSUE #5: t"
+
+
 def test_walk_promotes_only_confirmed_items(monkeypatch):
     _wire_repo(monkeypatch)
     monkeypatch.setattr(promote_mod, "list_promotable", lambda c, rn: [

--- a/tests/unit/test_promote.py
+++ b/tests/unit/test_promote.py
@@ -376,6 +376,9 @@ def test_promotable_summary_minimal_item_does_not_crash():
     # A bare item (e.g. a mocked one) renders just the title line.
     out = promote_mod._promotable_summary({"kind": "issue", "number": 5, "title": "t"})
     assert out == "ISSUE #5: t"
+    # An explicit None body must not crash (coerced to "").
+    out = promote_mod._promotable_summary({"kind": "issue", "number": 6, "title": "t", "body": None})
+    assert out == "ISSUE #6: t"
 
 
 def test_walk_promotes_only_confirmed_items(monkeypatch):


### PR DESCRIPTION
The `forge promote` walk previously printed only the title before each y/N prompt, which made it hard to tell what you were promoting — and let a stale CI-validation PR get promoted by accident.

Each item now shows enough to decide without leaving the terminal:
- head -> base branch and opened date (for PRs; issues show the date)
- a first-paragraph excerpt of the body (skips markdown headings like `## Summary`, collapses whitespace, caps length)
- the Forgejo URL to click through for full detail

`list_promotable` now carries `body`, `url`, `created_at`, and `head`/`base`; a new `_promotable_summary` renders the block. All fields are read defensively so a minimal item still renders just its title. Adds unit tests for the excerpt and summary helpers.